### PR TITLE
feat(#11): community 도메인 Mapper 및 XML 작성

### DIFF
--- a/src/main/groovy/com/yumyumcoach/domain/community/entity/Post.java
+++ b/src/main/groovy/com/yumyumcoach/domain/community/entity/Post.java
@@ -15,15 +15,17 @@ public class Post {
     private Long id;
     private String title;
     private String content;
-    private String category;
+//    private String category;
     private LocalDateTime createdAt;
     private int likes;
     private String authorEmail;
 
-    public void update(String title, String content, String category) {
+    // 나중에 category 추가시 주석 풀기
+//    public void update(String title, String content, String category) {
+    public void update(String title, String content) {
         this.title = title;
         this.content = content;
-        this.category = category;
+//        this.category = category;
     }
 
     public void increaseLikes() {
@@ -34,11 +36,13 @@ public class Post {
         this.likes--;
     }
 
-    public static Post newPost(String title, String content, String category, String authorEmail) {
+    // 나중에 category 추가시 주석 풀기
+//    public static Post newPost(String title, String content, String category, String authorEmail) {
+    public static Post newPost(String title, String content, String authorEmail) {
         return Post.builder()
                 .title(title)
                 .content(content)
-                .category(category)
+//                .category(category)
                 .authorEmail(authorEmail)
                 .createdAt(LocalDateTime.now())
                 .likes(0)

--- a/src/main/groovy/com/yumyumcoach/domain/community/entity/PostLike.java
+++ b/src/main/groovy/com/yumyumcoach/domain/community/entity/PostLike.java
@@ -1,0 +1,31 @@
+package com.yumyumcoach.domain.community.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PostLike {
+
+    /**
+     * 좋아요 대상 게시글 ID
+     */
+    private Long postId;
+
+    /**
+     * 좋아요 누른 사용자 이메일
+     * - 컬럼명은 email 이지만, 도메인에선 authorEmail로 통일
+     */
+    private String authorEmail;
+
+    /**
+     * 좋아요 누른 시각
+     */
+    private LocalDateTime createdAt;
+}

--- a/src/main/groovy/com/yumyumcoach/domain/community/mapper/PostLikeMapper.java
+++ b/src/main/groovy/com/yumyumcoach/domain/community/mapper/PostLikeMapper.java
@@ -1,4 +1,28 @@
 package com.yumyumcoach.domain.community.mapper;
 
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
 public interface PostLikeMapper {
+    /**
+     * 특정 유저가 특정 게시글에 좋아요 눌렀는지 여부
+     */
+    boolean existsByPostIdAndAuthorEmail(@Param("postId") Long postId,
+                                         @Param("authorEmail") String authorEmail);
+
+    /**
+     * 좋아요 추가
+     */
+    void insert(PostLike like);
+
+    /**
+     * 좋아요 취소
+     */
+    void deleteByPostIdAndAuthorEmail(@Param("postId") Long postId,
+                                      @Param("authorEmail") String authorEmail);
+
+    /**
+     * 특정 게시글의 좋아요 개수
+     */
+    long countByPostId(@Param("postId") Long postId);
 }

--- a/src/main/resources/mapper/community/PostCommentMapper.xml
+++ b/src/main/resources/mapper/community/PostCommentMapper.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.yumyumcoach.domain.community.mapper.PostCommentMapper">
+
+    <resultMap id="PostCommentResultMap" type="com.yumyumcoach.domain.community.entity.PostComment">
+        <id column="id" property="id"/>
+        <result column="post_id" property="postId"/>
+        <result column="author_email" property="authorEmail"/>
+        <result column="content" property="content"/>
+        <result column="created_at" property="createdAt"/>
+    </resultMap>
+
+    <!-- 특정 게시글의 댓글 목록 -->
+    <select id="findByPostId" parameterType="long" resultMap="PostCommentResultMap">
+        SELECT id, post_id, author_email, content, created_at
+        FROM post_comments
+        WHERE post_id = #{postId}
+        ORDER BY created_at ASC
+    </select>
+
+    <!-- 댓글 개수 -->
+    <select id="countByPostId" parameterType="long" resultType="long">
+        SELECT COUNT(*)
+        FROM post_comments
+        WHERE post_id = #{postId}
+    </select>
+
+    <!-- 댓글 단건 조회 -->
+    <select id="findById" parameterType="long" resultMap="PostCommentResultMap">
+        SELECT id, post_id, author_email, content, created_at
+        FROM post_comments
+        WHERE id = #{commentId}
+    </select>
+
+    <!-- 댓글 INSERT -->
+    <insert id="insert"
+            parameterType="com.yumyumcoach.domain.community.entity.PostComment"
+            useGeneratedKeys="true"
+            keyProperty="id">
+        INSERT INTO post_comments (
+            post_id, author_email, content,created_at
+        )
+        VALUES (
+           #{postId}, #{authorEmail}, #{content}, #{createdAt}
+               )
+    </insert>
+
+    <!-- 댓글 수정 -->
+    <update id="update" parameterType="com.yumyumcoach.domain.community.entity.PostComment">
+        UPDATE post_comments
+        SET content = #{content}
+        WHERE id = #{id}
+    </update>
+
+    <!-- 댓글 단건 삭제 -->
+    <delete id="delete" parameterType="long">
+        DELETE FROM post_comments
+        WHERE id = #{commentId}
+    </delete>
+
+    <!-- 게시글 삭제 시, 해당 게시글 댓글 전체 삭제 -->
+    <delete id="deleteByPostId" parameterType="long">
+        DELETE FROM post_comments
+        WHERE post_id = #{postId}
+    </delete>
+
+</mapper>

--- a/src/main/resources/mapper/community/PostImageMapper.xml
+++ b/src/main/resources/mapper/community/PostImageMapper.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.yumyumcoach.domain.community.mapper.PostImageMapper">
+
+    <resultMap id="PostImageResultMap" type="com.yumyumcoach.domain.community.entity.PostImage">
+        <id column="id" property="id"/>
+        <result column="post_id" property="postId"/>
+        <result column="image_url" property="imageUrl"/>
+        <result column="order_index" property="orderIndex"/>
+    </resultMap>
+
+    <!-- 특정 게시글의 이미지 목록 -->
+    <select id="findByPostId" parameterType="long" resultMap="PostImageResultMap">
+        SELECT id, post_id, image_url, order_index
+        FROM post_images
+        WHERE post_id = #{postId}
+        ORDER BY order_index ASC
+    </select>
+
+    <!-- 이미지 한 장 INSERT -->
+    <insert id="insert" parameterType="com.yumyumcoach.domain.community.entity.PostImage">
+        INSERT INTO post_images (
+            post_id, image_url, order_index
+        )
+        VALUES (
+           #{postId}, #{imageUrl}, #{orderIndex}
+               )
+    </insert>
+
+    <!-- 게시글 기준 전체 삭제 (게시글 삭제/이미지 재구성) -->
+    <delete id="deleteByPostId" parameterType="long">
+        DELETE FROM post_images
+        WHERE post_id = #{postId}
+    </delete>
+
+</mapper>

--- a/src/main/resources/mapper/community/PostLikeMapper.xml
+++ b/src/main/resources/mapper/community/PostLikeMapper.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.yumyumcoach.domain.community.mapper.PostLikeMapper">
+
+    <resultMap id="PostLikeResultMap" type="com.yumyumcoach.domain.community.entity.PostLike">
+        <result column="post_id" property="postId"/>
+        <result column="email" property="authorEmail"/>
+        <result column="created_at" property="createdAt"/>
+    </resultMap>
+
+    <!-- 좋아요 존재 여부 -->
+    <select id="existsByPostIdAndAuthorEmail" parameterType="map" resultType="boolean">
+        SELECT IF(COUNT(*) > 0, TRUE, FALSE)
+        FROM post_likes
+        WHERE post_id = #{postId}
+          AND email = #{authorEmail}
+    </select>
+
+    <!-- 좋아요 추가 -->
+    <insert id="insert" parameterType="com.yumyumcoach.domain.community.entity.PostLike">
+        INSERT INTO post_likes (
+            post_id, email, created_at
+        )
+        VALUES (
+           #{postId}, #{authorEmail}, #{createdAt}
+               )
+    </insert>
+
+    <!-- 좋아요 취소 -->
+    <delete id="deleteByPostIdAndAuthorEmail" parameterType="map">
+        DELETE FROM post_likes
+        WHERE post_id = #{postId}
+          AND email = #{authorEmail}
+    </delete>
+
+    <!-- 특정 게시글의 좋아요 개수 -->
+    <select id="countByPostId" parameterType="long" resultType="long">
+        SELECT COUNT(*)
+        FROM post_likes
+        WHERE post_id = #{postId}
+    </select>
+
+</mapper>

--- a/src/main/resources/mapper/community/PostMapper.xml
+++ b/src/main/resources/mapper/community/PostMapper.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.yumyumcoach.domain.community.mapper.PostMapper">
+    <resultMap id="PostResultMap" type="com.yumyumcoach.domain.community.entity.Post">
+        <id column="id" property="id"/>
+        <result column="author_email" property="authorEmail"/>
+        <result column="title" property="title"/>
+        <result column="content" property="content"/>
+        <result column="created_at" property="createdAt"/>
+        <result column="likes" property="likes"/>
+    </resultMap>
+
+    <!-- 단건 조회 -->
+    <select id="findById" parameterType="long" resultMap="PostResultMap">
+        SELECT id, author_email, title, content, created_at, likes
+        FROM posts
+        WHERE id = #{postId}
+    </select>
+
+    <!-- 목록 조회 (페이징) -->
+    <select id="findPosts" parameterType="map" resultMap="PostResultMap">
+        SELECT id, author_email, title, content, created_at, likes
+        FROM posts
+        <!-- [TODO] keyword, sort 나중에 조건 추가 -->
+        ORDER BY created_at DESC
+        LIMIT #{size} OFFSET #{offset}
+    </select>
+
+    <!-- 전체 게시글 개수 -->
+    <select id="countPosts" parameterType="map" resultType="long">
+        SELECT COUNT(*)
+        FROM posts
+        <!-- [TODO] keyword 조건 나중에 추가 -->
+    </select>
+
+    <!-- INSERT -->
+    <insert id="insert" parameterType="com.yumyumcoach.domain.community.entity.Post" useGeneratedKeys="true" keyProperty="id">
+        INSERT INTO posts (
+            author_email, title, content, created_at, likes
+        )
+        VALUES (
+           #{authorEmail}, #{title}, #{content}, #{createdAt}, #{likes}
+               )
+    </insert>
+
+    <!-- UPDATE -->
+    <update id="update" parameterType="com.yumyumcoach.domain.community.entity.Post">
+        UPDATE posts
+        SET title = #{title}, content = #{content}
+        WHERE id = #{id}
+    </update>
+
+    <!-- DELETE -->
+    <delete id="delete" parameterType="long">
+        DELETE FROM posts
+        WHERE id = #{postId}
+    </delete>
+
+    <!-- 좋아요 +1 -->
+    <update id="increaseLikes" parameterType="long">
+        UPDATE posts
+        SET likes = likes + 1
+        WHERE id = #{postId}
+    </update>
+
+    <!-- 좋아요 -1 (0 아래로 안 내려가게) -->
+    <update id="decreaseLikes" parameterType="long">
+        UPDATE posts
+        SET likes = IF(likes > 0, likes - 1, 0)
+        WHERE id = #{postId}
+    </update>
+</mapper>


### PR DESCRIPTION
## 🔗 관련 이슈

- #11

## ✨ 작업 내용

- Community domain의 MyBatis mapper XML 작성
- like (좋아요) 엔티티 및 mapper 인터페이스, xml 작성
  - `PostMapper.xml` / `PostImageMapper.xml` / `PostCommentMapper.xml` / `PostLikeMapper.xml` 추가
  - `PostLike` 엔티티 및 `PostLikeMapper` 인터페이스 작성
- posts / post_images / post_comments / post_likes 스키마 기준으로 기본 CRUD, 카운트, exists 쿼리 정의
- 추후 서비스 레이어에서 사용할 수 있도록 기본적인 ResultMap, parameterType 설정

## 📌 참고 사항

- 아직 서비스 로직은 미구현 상태
