### PR TITLE
fix(#18): MyBatis 설정 및 Security 개발용 설정 정리

### DIFF
--- a/src/main/groovy/com/yumyumcoach/domain/community/controller/CommentController.java
+++ b/src/main/groovy/com/yumyumcoach/domain/community/controller/CommentController.java
@@ -1,0 +1,55 @@
+package com.yumyumcoach.domain.community.controller;
+
+import com.yumyumcoach.domain.community.dto.CommentRequest;
+import com.yumyumcoach.domain.community.dto.CommentResponse;
+import com.yumyumcoach.domain.community.dto.GetCommentsResponse;
+import com.yumyumcoach.domain.community.service.CommentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * Community 댓글 관련 컨트롤러.
+ * - /api/posts/{postId}/comments 하위 엔드포인트 담당
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/posts/{postId}/comments")
+public class CommentController {
+
+    private final CommentService commentService;
+
+    // 특정 게시글의 댓글 목록 조회
+    @GetMapping
+    public GetCommentsResponse getComments(@PathVariable Long postId) {
+        return commentService.getComments(postId);
+    }
+
+    // 댓글 작성
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public CommentResponse createComment(@PathVariable Long postId,
+                                         @RequestBody CommentRequest request) {
+        Long loginUserId = 1L; // TODO: 인증 연동 후 실제 사용자 ID 주입
+        return commentService.createComment(loginUserId, postId, request);
+    }
+
+    // 댓글 수정
+    @PutMapping("/{commentId}")
+    public CommentResponse updateComment(@PathVariable Long postId,
+                                         @PathVariable Long commentId,
+                                         @RequestBody CommentRequest request) {
+        Long loginUserId = 1L; // TODO
+        return commentService.updateComment(loginUserId, postId, commentId, request);
+    }
+
+    // 댓글 삭제
+    @DeleteMapping("/{commentId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void deleteComment(@PathVariable Long postId,
+                              @PathVariable Long commentId) {
+        Long loginUserId = 1L; // TODO
+        commentService.deleteComment(loginUserId, postId, commentId);
+    }
+}
+

--- a/src/main/groovy/com/yumyumcoach/domain/community/controller/PostController.java
+++ b/src/main/groovy/com/yumyumcoach/domain/community/controller/PostController.java
@@ -1,0 +1,74 @@
+package com.yumyumcoach.domain.community.controller;
+
+import com.yumyumcoach.domain.community.dto.GetPostsRequest;
+import com.yumyumcoach.domain.community.dto.GetPostsResponse;
+import com.yumyumcoach.domain.community.dto.PostRequest;
+import com.yumyumcoach.domain.community.dto.PostResponse;
+import com.yumyumcoach.domain.community.service.PostService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * Community 게시글 관련 컨트롤러.
+ * - /api/posts 하위 엔드포인트 담당
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/posts")
+public class PostController {
+    private final PostService postService;
+
+    // 전체 게시글 목록 조회
+    @GetMapping
+    public GetPostsResponse getPosts(GetPostsRequest request) {
+        Long loginUserId = 1L; // TODO: 인증 연동 후 교체
+        return postService.getPosts(request, loginUserId);
+    }
+
+    // 게시글 상세 조회
+    @GetMapping("/{postId}")
+    public PostResponse getPost(@PathVariable Long postId) {
+        Long loginUserId = 1L; // TODO: 인증 연동 후 교체
+        return postService.getPost(postId, loginUserId);
+    }
+
+    // 게시글 작성
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public PostResponse post(@RequestBody PostRequest request) {
+        Long loginUserId = 1L; // TODO: 인증 연동 후 교체
+        return postService.createPost(loginUserId, request);
+    }
+
+    // 게시글 수정
+    @PutMapping("/{postId}")
+    public PostResponse updatePost(@PathVariable Long postId, @RequestBody PostRequest request) {
+        Long loginUserId = 1L; // TODO: 인증 연동 후 교체
+        return postService.updatePost(loginUserId, postId, request);
+    }
+
+    // 게시글 삭제
+    @DeleteMapping("/{postId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void deletePost(@PathVariable Long postId) {
+        Long loginUserId = 1L; // TODO: 인증 연동 후 교체
+        postService.deletePost(loginUserId, postId);
+    }
+
+    // 게시글 좋아요
+    @PostMapping("/{postId}/like")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void likePost(@PathVariable Long postId) {
+        Long loginUserId = 1L; // TODO: 인증 연동 후 교체
+        postService.likePost(loginUserId, postId);
+    }
+
+    // 게시글 좋아요 취소
+    @DeleteMapping("/{postId}/like")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void unlikePost(@PathVariable Long postId) {
+        Long loginUserId = 1L; // TODO: 인증 연동 후 교체
+        postService.unlikePost(loginUserId, postId);
+    }
+}

--- a/src/main/groovy/com/yumyumcoach/global/config/SecurityConfig.java
+++ b/src/main/groovy/com/yumyumcoach/global/config/SecurityConfig.java
@@ -1,0 +1,23 @@
+package com.yumyumcoach.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests(auth -> auth
+                        //  api 테스트를 위해 권한 절차 해제
+                        .anyRequest().permitAll()
+                );
+        return http.build();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,13 +14,13 @@ spring:
     password: ssafy
     driver-class-name: com.mysql.cj.jdbc.Driver
 
-  mybatis:
-    mapper-locations: classpath*:mapper/**/*.xml
-    type-aliases-package: com.yumyumcoach.domain
-
 server:
   port: 8080
 
 logging:
   level:
     root: info
+
+mybatis:
+  mapper-locations: classpath*:mapper/**/*.xml
+  type-aliases-package: com.yumyumcoach.domain


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #18

## ✨ 작업 내용

- mybatis 설정을 spring 블럭 밖 루트 레벨로 이동하여 Mapper 설정이 정상 적용되도록 수정
- 개발 단계 API 테스트를 위해 Spring Security에서 `anyRequest().permitAll()` 임시 적용
-
## 📌 참고 사항

- auth 쪽 완료 후 인증/인가 적용 예정