### PR TITLE
refactor: diet_foods테이블의 weight속성 변경

### DIFF
--- a/db/20251212_refactoring_diet_foods.sql
+++ b/db/20251212_refactoring_diet_foods.sql
@@ -1,0 +1,2 @@
+ALTER TABLE diet_foods
+  CHANGE COLUMN weight serve_count DOUBLE DEFAULT NULL;

--- a/db/20251212_refactoring_diet_foods.sql
+++ b/db/20251212_refactoring_diet_foods.sql
@@ -1,2 +1,3 @@
 ALTER TABLE diet_foods
-  CHANGE COLUMN weight serve_count DOUBLE DEFAULT NULL;
+  CHANGE COLUMN weight serve_count DOUBLE NOT NULL DEFAULT 1;
+


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #23

## ✨ 작업 내용

- diet_foods테이블의 weight(VARCHAR)속성을 serve_count(DOUBLE)로 변경하는 SQL문 추가


## 📌 참고 사항

적용 방법

**window 기준**

1. 머지 이후 git pull origin develop해서 sql문 받아오기
2. 터미널에 다음과 같이 명령어 입력
 Get-Content .\db\20251212_refactoring_diet_foods.sql | docker exec -i yumyumcoach-mysql mysql -u root -pssafy yumyumcoach
3. mysql workbench에서 적용됬는지 확인 (만약 없다면 아래 코드를 통해 확인)
docker exec -i yumyumcoach-mysql mysql -uroot -pssafy
USE yumyumcoach;
SHOW TABLES;
4. 도커 재실행 (docker compose down / docker compose up -d mysql)

**mac 기준**

1. 머지 이후 git pull origin develop해서 sql문 받아오기
2. 터미널에 다음과 같이 명령어 입력
cat ./db/20251212_refactoring_diet_foods.sql | docker exec -i yumyumcoach-mysql mysql -uroot -pssafy
3. 아래 코드를 통해 확인
docker exec -it yumyumcoach-mysql mysql -uroot -pssafy
SHOW DATABASES;
USE yumyumcoach;
SHOW TABLES;
4. 도커 재실행 (docker compose down / docker compose up -d mysql)