### PR TITLE
refactor(#28): challenge API 스키마/엔티티 명세서 수정

### DIFF
--- a/db/20251212_refactoring_challenge_1.sql
+++ b/db/20251212_refactoring_challenge_1.sql
@@ -29,3 +29,8 @@ DROP TABLE IF EXISTS challenge_types;
 
 ALTER TABLE challenges
     ADD COLUMN challenge_type VARCHAR(20) NOT NULL DEFAULT 'PUBLIC';
+
+ALTER TABLE challenge_participants
+    ADD COLUMN success_days INT NOT NULL DEFAULT 0
+        AFTER progress_percentage;
+

--- a/db/20251212_refactoring_challenge_1.sql
+++ b/db/20251212_refactoring_challenge_1.sql
@@ -1,0 +1,31 @@
+USE yumyumcoach;
+
+CREATE TABLE IF NOT EXISTS challenge_rules (
+                                               challenge_id          BIGINT UNSIGNED NOT NULL,
+                                               difficulty_code       VARCHAR(255) NOT NULL,  -- BEGINNER / INTERMEDIATE / ADVANCED
+                                               required_success_days INT NOT NULL,           -- 최소 성공해야 하는 일수
+                                               daily_target_value    DOUBLE DEFAULT NULL,    -- 하루 목표 값 (단순 일수 기준이면 NULL)
+
+                                               PRIMARY KEY (challenge_id, difficulty_code),
+                                               CONSTRAINT fk_challenge_rules_challenge
+                                                   FOREIGN KEY (challenge_id) REFERENCES challenges(id),
+                                               CONSTRAINT fk_challenge_rules_difficulty
+                                                   FOREIGN KEY (difficulty_code) REFERENCES challenge_difficulties(code)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+ALTER TABLE challenges
+    DROP FOREIGN KEY fk_challenges_type;
+
+ALTER TABLE challenges
+    DROP COLUMN type_code;
+
+ALTER TABLE challenges
+    DROP FOREIGN KEY fk_challenges_difficulty;
+
+ALTER TABLE challenges
+    DROP COLUMN difficulty_code;
+
+DROP TABLE IF EXISTS challenge_types;
+
+ALTER TABLE challenges
+    ADD COLUMN challenge_type VARCHAR(20) NOT NULL DEFAULT 'PUBLIC';

--- a/src/main/groovy/com/yumyumcoach/domain/challenge/dto/ChallengeListResponse.java
+++ b/src/main/groovy/com/yumyumcoach/domain/challenge/dto/ChallengeListResponse.java
@@ -1,0 +1,30 @@
+package com.yumyumcoach.domain.challenge.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/**
+ * 챌린지 목록 전체 응답 DTO.
+ * GET /api/challenges?month=YYYY-MM
+ */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChallengeListResponse {
+
+    /**
+     * 조회 기준 월 (YYYY-MM 형식 문자열)
+     * 예) "2025-12"
+     */
+    private String month;
+
+    /**
+     * 해당 월에 노출되는 챌린지 목록
+     */
+    private List<ChallengeResponse> challenges;
+}

--- a/src/main/groovy/com/yumyumcoach/domain/challenge/dto/ChallengeResponse.java
+++ b/src/main/groovy/com/yumyumcoach/domain/challenge/dto/ChallengeResponse.java
@@ -55,7 +55,7 @@ public class ChallengeResponse {
 
     /**
      * 챌린지 타입 코드
-     * 예) "PUBLIC"
+     * 예) "PUBLIC"(운영자 생성), "USER"(사용자 생성)
      */
     private String type;
 
@@ -76,12 +76,6 @@ public class ChallengeResponse {
      * 예) 2025-11-30
      */
     private String endDate;
-
-    /**
-     * 추천 난이도 코드
-     * 예) "BEGINNER", "INTERMEDIATE", "ADVANCED"
-     */
-    private String recommendedDifficulty;
 
     /**
      * 현재 챌린지에 참여 중인 인원 수

--- a/src/main/groovy/com/yumyumcoach/domain/challenge/dto/ChallengeResponse.java
+++ b/src/main/groovy/com/yumyumcoach/domain/challenge/dto/ChallengeResponse.java
@@ -1,0 +1,134 @@
+package com.yumyumcoach.domain.challenge.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 공용 챌린지 응답 DTO.
+ * - 목록 카드
+ * - 상세 조회
+ * 두 곳에서 모두 사용한다.
+ */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChallengeResponse {
+
+    // ====== 공용 챌린지 기본 정보 ======
+
+    /**
+     * 챌린지 ID
+     */
+    private Long challengeId;
+
+    /**
+     * 챌린지 제목 (이름)
+     * 예) 11월 식단 기록 챌린지
+     */
+    private String title;
+
+    /**
+     * 짧은 설명
+     * 예) 11월 한 달 중 목표 일수만큼 식단을 기록하면 성공
+     */
+    private String shortDescription;
+
+    /**
+     * 목표 한 줄 요약
+     * 상세 화면 상단에 노출할 수 있는 문구
+     */
+    private String goalSummary;
+
+    /**
+     * 상세 규칙 설명
+     * 난이도별 조건, 유의 사항 등 긴 설명 텍스트
+     */
+    private String ruleDescription;
+
+    /**
+     * 챌린지 대표 이미지 URL
+     */
+    private String imageUrl;
+
+    /**
+     * 챌린지 타입 코드
+     * 예) "PUBLIC"
+     */
+    private String type;
+
+    /**
+     * 목표 판정 타입 코드
+     * 예) "DAY_COUNT_SIMPLE", "PROTEIN_PER_DAY", "EXERCISE_MINUTES_PER_DAY"
+     */
+    private String goalType;
+
+    /**
+     * 챌린지 시작일 (yyyy-MM-dd)
+     * 예) 2025-11-01
+     */
+    private String startDate;
+
+    /**
+     * 챌린지 종료일 (yyyy-MM-dd)
+     * 예) 2025-11-30
+     */
+    private String endDate;
+
+    /**
+     * 추천 난이도 코드
+     * 예) "BEGINNER", "INTERMEDIATE", "ADVANCED"
+     */
+    private String recommendedDifficulty;
+
+    /**
+     * 현재 챌린지에 참여 중인 인원 수
+     */
+    private Integer participantsCount;
+
+    // ====== 내 참여 정보 (참여 중일 때만 의미 있음) ======
+
+    /**
+     * 현재 사용자가 이 챌린지에 참여 중인지 여부
+     */
+    private Boolean isJoined;
+
+    /**
+     * 내가 선택한 난이도 코드
+     * 예) "INTERMEDIATE"
+     * 참여하지 않은 경우 null
+     */
+    private String selectedDifficulty;
+
+    /**
+     * 나에게 요구되는 최소 성공 일수
+     * 예) 12
+     * 참여하지 않은 경우 null
+     */
+    private Integer requiredSuccessDays;
+
+    /**
+     * 하루 기준 목표 값
+     * 예) 단백질 g, 운동 분 등
+     * 단순 일수 챌린지는 null 일 수 있음
+     */
+    private Double dailyTargetValue;
+
+    /**
+     * 현재까지 성공한 일수
+     * 예) 5
+     * 참여하지 않은 경우 null
+     */
+    private Integer successDays;
+
+    /**
+     * 현재 진행률 (0.0 ~ 100.0)
+     * 예) 45.0
+     * 참여하지 않은 경우 null
+     */
+    private Double progressPercentage;
+}
+
+

--- a/src/main/groovy/com/yumyumcoach/domain/challenge/dto/JoinChallengeRequest.java
+++ b/src/main/groovy/com/yumyumcoach/domain/challenge/dto/JoinChallengeRequest.java
@@ -1,0 +1,20 @@
+package com.yumyumcoach.domain.challenge.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 챌린지 참여 요청 DTO.
+ * POST /api/challenges/{challengeId}/join
+ */
+@Getter
+@NoArgsConstructor
+public class JoinChallengeRequest {
+
+    /**
+     * 참여 시 선택한 난이도 코드
+     * 예) "BEGINNER", "INTERMEDIATE", "ADVANCED"
+     */
+    private String difficultyCode;
+}
+

--- a/src/main/groovy/com/yumyumcoach/domain/challenge/dto/JoinChallengeResponse.java
+++ b/src/main/groovy/com/yumyumcoach/domain/challenge/dto/JoinChallengeResponse.java
@@ -1,0 +1,67 @@
+package com.yumyumcoach.domain.challenge.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 챌린지 참여 성공 시 응답 DTO.
+ */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class JoinChallengeResponse {
+
+    /**
+     * 챌린지 ID
+     */
+    private Long challengeId;
+
+    /**
+     * 챌린지 제목 (이름)
+     */
+    private String title;
+
+    /**
+     * 참여 여부 (성공 시 항상 true)
+     */
+    private Boolean joined;
+
+    /**
+     * 참여 시각
+     * 예) "2025-11-20T09:00:00"
+     */
+    private String joinedAt;
+
+    /**
+     * 선택한 난이도 코드
+     * 예) "INTERMEDIATE"
+     */
+    private String difficultyCode;
+
+    /**
+     * 나에게 요구되는 최소 성공 일수
+     * 예) 12
+     */
+    private Integer requiredSuccessDays;
+
+    /**
+     * 하루 기준 목표 값
+     * 예) 단백질 g, 운동 분 등
+     * 단순 일수 챌린지는 null 일 수 있음
+     */
+    private Double dailyTargetValue;
+
+    /**
+     * 나의 챌린지 기간 시작일 (yyyy-MM-dd)
+     */
+    private String myStartDate;
+
+    /**
+     * 나의 챌린지 기간 종료일 (yyyy-MM-dd)
+     */
+    private String myEndDate;
+}
+

--- a/src/main/groovy/com/yumyumcoach/domain/challenge/dto/LeaveChallengeResponse.java
+++ b/src/main/groovy/com/yumyumcoach/domain/challenge/dto/LeaveChallengeResponse.java
@@ -1,0 +1,35 @@
+package com.yumyumcoach.domain.challenge.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 챌린지 나가기 응답 DTO.
+ * DELETE /api/challenges/{challengeId}/leave
+ */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class LeaveChallengeResponse {
+
+    /**
+     * 챌린지 ID
+     */
+    private Long challengeId;
+
+    /**
+     * 나가기 처리 여부
+     * 성공 시 true
+     */
+    private Boolean left;
+
+    /**
+     * 나간 시각
+     * 예) "2025-11-25T18:00:00"
+     */
+    private String leftAt;
+}
+

--- a/src/main/groovy/com/yumyumcoach/domain/challenge/entity/Challenge.java
+++ b/src/main/groovy/com/yumyumcoach/domain/challenge/entity/Challenge.java
@@ -66,6 +66,12 @@ public class Challenge {
     private String imageUrl;
 
     /**
+     * 챌린지 타입
+     * 예) PUBLIC(운영자), USER(사용자 생성)
+     */
+    private String challengeType;
+
+    /**
      * 모집 시작일
      * 이 날짜부터 챌린지 참여 신청이 가능함
      */

--- a/src/main/groovy/com/yumyumcoach/domain/challenge/entity/Challenge.java
+++ b/src/main/groovy/com/yumyumcoach/domain/challenge/entity/Challenge.java
@@ -1,0 +1,126 @@
+package com.yumyumcoach.domain.challenge.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Challenge {
+
+    /**
+     * 챌린지 ID (PK, challenges.id)
+     */
+    private Long id;
+
+    /**
+     * 완료 시 부여되는 칭호 ID (FK, titles.id)
+     * 없을 수 있음(null 가능)
+     */
+    private Long rewardTitleId;
+
+    /**
+     * 챌린지 이름
+     * 예) 11월 단백질 챌린지
+     */
+    private String name;
+
+    /**
+     * 짧은 설명
+     * 챌린지 카드 리스트 등에서 한 줄로 보여줄 요약
+     */
+    private String shortDescription;
+
+    /**
+     * 기본/추천 난이도 코드
+     * 예) BEGINNER / INTERMEDIATE / ADVANCED
+     */
+    private String difficultyCode;
+
+    /**
+     * 목표 한 줄 요약
+     * 예) 11월 중 12일 이상 단백질 목표 달성
+     */
+    private String goalSummary;
+
+    /**
+     * 상세 규칙 설명
+     * 난이도별 조건, 유의 사항 등을 자유롭게 서술
+     */
+    private String ruleDescription;
+
+    /**
+     * 챌린지 타입 코드
+     * 예) PUBLIC / SEASONAL / DISEASE_SPECIFIC 등
+     */
+    private String typeCode;
+
+    /**
+     * 챌린지 대표 이미지 URL
+     */
+    private String imageUrl;
+
+    /**
+     * 모집 시작일
+     * 이 날짜부터 챌린지 참여 신청이 가능함
+     */
+    private LocalDate recruitStartDate;
+
+    /**
+     * 모집 종료일
+     * 이 날짜까지만 챌린지 참여 신청이 가능함
+     */
+    private LocalDate recruitEndDate;
+
+    /**
+     * 챌린지 시작일
+     * 해당 월의 시작일(예: 2025-11-01)
+     */
+    private LocalDate startDate;
+
+    /**
+     * 챌린지 종료일
+     * 해당 월의 말일(예: 2025-11-30)
+     */
+    private LocalDate endDate;
+
+    /**
+     * 챌린지 활성화 여부
+     * 관리용 플래그 (1/0 → true/false)
+     */
+    private Boolean isActive;
+
+    /**
+     * 목표 판정 타입
+     * 예) DAY_COUNT_SIMPLE / PROTEIN_PER_DAY / EXERCISE_MINUTES_PER_DAY
+     */
+    private String goalType;
+
+    /**
+     * 주어진 날짜 기준으로, 모집 기간(recruitStartDate ~ recruitEndDate) 내에 있는지 여부를 반환한다.
+     *
+     * @param today 오늘 날짜
+     * @return 모집 중이면 true, 아니면 false
+     */
+    public boolean isRecruitingOn(LocalDate today) {
+        return (today.isEqual(recruitStartDate) || today.isAfter(recruitStartDate))
+                && (today.isEqual(recruitEndDate) || today.isBefore(recruitEndDate));
+    }
+
+    /**
+     * 주어진 날짜 기준으로, 챌린지가 진행 중(startDate ~ endDate)인지 여부를 반환한다.
+     *
+     * @param today 오늘 날짜
+     * @return 진행 중이면 true, 아니면 false
+     */
+    public boolean isRunningOn(LocalDate today) {
+        return (today.isEqual(startDate) || today.isAfter(startDate))
+                && (today.isEqual(endDate) || today.isBefore(endDate));
+    }
+}
+

--- a/src/main/groovy/com/yumyumcoach/domain/challenge/entity/ChallengeParticipant.java
+++ b/src/main/groovy/com/yumyumcoach/domain/challenge/entity/ChallengeParticipant.java
@@ -1,0 +1,138 @@
+package com.yumyumcoach.domain.challenge.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChallengeParticipant {
+
+    /**
+     * 챌린지 ID (FK, challenges.id)
+     * PK 복합 키의 일부 (challenge_id, email)
+     */
+    private Long challengeId;
+
+    /**
+     * 참여한 사용자 이메일 (FK, accounts.email)
+     * PK 복합 키의 일부 (challenge_id, email)
+     */
+    private String email;
+
+    /**
+     * 이 사용자가 챌린지에 참여한 시각
+     */
+    private LocalDateTime joinedAt;
+
+    /**
+     * 참여 상태
+     * 예) joined / completed / left
+     */
+    private String status;
+
+    /**
+     * 선택한 난이도 코드
+     * 예) BEGINNER / INTERMEDIATE / ADVANCED
+     */
+    private String difficultyCode;
+
+    /**
+     * 이 유저 기준 최소 성공해야 하는 일수
+     * 예) 초급 8일, 중급 12일, 고급 20일 등
+     */
+    private Integer requiredSuccessDays;
+
+    /**
+     * 하루 기준 목표 값
+     * 예) 단백질 g, 운동 분 등
+     * 단순 "기록만 있으면 성공"인 챌린지는 null 일 수 있음
+     */
+    private Double dailyTargetValue;
+
+    /**
+     * 진행률(0.0 ~ 100.0)
+     * 성공한 일수 / requiredSuccessDays * 100 으로 계산한 값을 캐싱
+     */
+    private Double progressPercentage;
+
+    /**
+     * 마지막으로 진행률/성공 일수를 계산한 시각
+     */
+    private LocalDateTime lastEvaluatedAt;
+
+    /**
+     * 챌린지를 완료했거나, 중도에 나간 시각
+     * status가 completed/left로 바뀔 때 함께 세팅
+     */
+    private LocalDateTime completedAt;
+
+    /**
+     * 새로 챌린지에 참여할 때 사용할 팩토리 메서드.
+     * joinedAt 은 현재 시각(LocalDateTime.now())으로 세팅하고,
+     * status 는 "joined", progressPercentage 는 0.0 으로 시작한다.
+     *
+     * @param challengeId         챌린지 ID
+     * @param email               사용자 이메일
+     * @param difficultyCode      선택한 난이도 코드
+     * @param requiredSuccessDays 이 유저 기준 최소 성공 일수
+     * @param dailyTargetValue    하루 기준 목표 값 (단순 일수형이면 null)
+     * @return 새로 생성된 ChallengeParticipant
+     */
+    public static ChallengeParticipant newJoin(
+            Long challengeId,
+            String email,
+            String difficultyCode,
+            int requiredSuccessDays,
+            Double dailyTargetValue
+    ) {
+        return ChallengeParticipant.builder()
+                .challengeId(challengeId)
+                .email(email)
+                .joinedAt(LocalDateTime.now())
+                .status("joined")
+                .difficultyCode(difficultyCode)
+                .requiredSuccessDays(requiredSuccessDays)
+                .dailyTargetValue(dailyTargetValue)
+                .progressPercentage(0.0)
+                .build();
+    }
+
+    /**
+     * 챌린지를 성공적으로 완료했을 때 상태/시간/진행률을 업데이트한다.
+     *
+     * @param completedAt 완료 시각
+     */
+    public void complete(LocalDateTime completedAt) {
+        this.status = "completed";
+        this.completedAt = completedAt;
+        this.progressPercentage = 100.0;
+    }
+
+    /**
+     * 챌린지에서 중도 탈퇴할 때 상태/시간을 업데이트한다.
+     *
+     * @param leftAt 나간 시각
+     */
+    public void leave(LocalDateTime leftAt) {
+        this.status = "left";
+        this.completedAt = leftAt;
+    }
+
+    /**
+     * 진행률과 마지막 평가 시각을 갱신한다.
+     *
+     * @param progressPercentage 새 진행률 (0.0 ~ 100.0)
+     * @param evaluatedAt        평가 시각
+     */
+    public void updateProgress(Double progressPercentage, LocalDateTime evaluatedAt) {
+        this.progressPercentage = progressPercentage;
+        this.lastEvaluatedAt = evaluatedAt;
+    }
+}
+

--- a/src/main/groovy/com/yumyumcoach/domain/challenge/entity/ChallengeParticipant.java
+++ b/src/main/groovy/com/yumyumcoach/domain/challenge/entity/ChallengeParticipant.java
@@ -62,6 +62,12 @@ public class ChallengeParticipant {
     private Double progressPercentage;
 
     /**
+     * 성공한 일수
+     * 조건을 만족한 날짜 수를 캐싱해두는 값
+     */
+    private Integer successDays;
+
+    /**
      * 마지막으로 진행률/성공 일수를 계산한 시각
      */
     private LocalDateTime lastEvaluatedAt;
@@ -100,6 +106,9 @@ public class ChallengeParticipant {
                 .requiredSuccessDays(requiredSuccessDays)
                 .dailyTargetValue(dailyTargetValue)
                 .progressPercentage(0.0)
+                .successDays(0)
+                .lastEvaluatedAt(null)
+                .completedAt(null)
                 .build();
     }
 
@@ -127,10 +136,12 @@ public class ChallengeParticipant {
     /**
      * 진행률과 마지막 평가 시각을 갱신한다.
      *
+     * @param successDays        성공한 일수
      * @param progressPercentage 새 진행률 (0.0 ~ 100.0)
      * @param evaluatedAt        평가 시각
      */
-    public void updateProgress(Double progressPercentage, LocalDateTime evaluatedAt) {
+    public void updateProgress(Integer successDays, Double progressPercentage, LocalDateTime evaluatedAt) {
+        this.successDays = successDays;
         this.progressPercentage = progressPercentage;
         this.lastEvaluatedAt = evaluatedAt;
     }

--- a/src/main/groovy/com/yumyumcoach/domain/challenge/entity/ChallengeRule.java
+++ b/src/main/groovy/com/yumyumcoach/domain/challenge/entity/ChallengeRule.java
@@ -1,0 +1,36 @@
+package com.yumyumcoach.domain.challenge.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChallengeRule {
+
+    /**
+     * 챌린지 ID (FK, challenges.id)
+     */
+    private Long challengeId;
+
+    /**
+     * 난이도 코드 (BEGINNER / INTERMEDIATE / ADVANCED)
+     */
+    private String difficultyCode;
+
+    /**
+     * 최소 성공해야 하는 일수
+     */
+    private Integer requiredSuccessDays;
+
+    /**
+     * 하루 목표 값
+     * - DAY_COUNT_SIMPLE 타입인 경우 null 일 수 있다.
+     * - PROTEIN_PER_DAY: g
+     * - EXERCISE_MINUTES_PER_DAY: 분
+     */
+    private Double dailyTargetValue;
+}

--- a/src/main/groovy/com/yumyumcoach/domain/challenge/mapper/ChallengeMapper.java
+++ b/src/main/groovy/com/yumyumcoach/domain/challenge/mapper/ChallengeMapper.java
@@ -1,0 +1,41 @@
+package com.yumyumcoach.domain.challenge.mapper;
+
+import com.yumyumcoach.domain.challenge.entity.Challenge;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * 공용 챌린지(challenges) 테이블용 MyBatis Mapper.
+ */
+@Mapper
+public interface ChallengeMapper {
+
+    /**
+     * 특정 기간에 시작되는 챌린지 목록을 조회한다.
+     * - 이번 달 챌린지, 다음 달 챌린지 등 조회에 사용.
+     *
+     * @param startDate 조회 시작일(포함)
+     * @param endDate   조회 종료일(포함)
+     * @return 기간에 속한 챌린지 목록
+     */
+    List<Challenge> findByPeriod(@Param("startDate") LocalDate startDate, @Param("endDate") LocalDate endDate);
+
+    /**
+     * 챌린지 ID로 단일 챌린지를 조회한다.
+     *
+     * @param challengeId 챌린지 ID
+     * @return 해당 챌린지, 없으면 null
+     */
+    Challenge findById(@Param("challengeId") Long challengeId);
+
+    /**
+     * 특정 챌린지에 참여 중인 인원 수를 조회한다.
+     *
+     * @param challengeId 챌린지 ID
+     * @return 참여자 수
+     */
+    int countParticipants(@Param("challengeId") Long challengeId);
+}

--- a/src/main/groovy/com/yumyumcoach/domain/challenge/mapper/ChallengeParticipantMapper.java
+++ b/src/main/groovy/com/yumyumcoach/domain/challenge/mapper/ChallengeParticipantMapper.java
@@ -1,0 +1,86 @@
+package com.yumyumcoach.domain.challenge.mapper;
+
+
+import com.yumyumcoach.domain.challenge.entity.ChallengeParticipant;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.time.LocalDateTime;
+
+/**
+ * 공용 챌린지 참여 정보(challenge_participants) 테이블용 MyBatis Mapper.
+ */
+@Mapper
+public interface ChallengeParticipantMapper {
+
+    /**
+     * 챌린지 ID와 이메일로 단일 참여 정보를 조회한다.
+     *
+     * @param challengeId 챌린지 ID
+     * @param email       사용자 이메일
+     * @return 참여 정보, 없으면 null
+     */
+    ChallengeParticipant findByChallengeIdAndEmail(@Param("challengeId") Long challengeId, @Param("email") String email);
+
+    /**
+     * 사용자가 해당 챌린지에 이미 참여 중인지 여부를 조회한다.
+     *
+     * @param challengeId 챌린지 ID
+     * @param email       사용자 이메일
+     * @return 이미 존재하면 1 이상, 아니면 0
+     */
+    int existsByChallengeIdAndEmail(@Param("challengeId") Long challengeId, @Param("email") String email);
+
+    /**
+     * 새로운 챌린지 참여 정보를 추가한다.
+     *
+     * @param participant 참여 엔티티
+     * @return insert된 row 수
+     */
+    int insert(ChallengeParticipant participant);
+
+    /**
+     * 참여 상태를 변경한다.
+     * 예) joined → completed
+     *
+     * @param challengeId 챌린지 ID
+     * @param email       사용자 이메일
+     * @param status      변경할 상태 값
+     * @param completedAt 완료/탈퇴 시각 (nullable)
+     * @return 업데이트된 row 수
+     */
+    int updateStatus(
+            @Param("challengeId") Long challengeId,
+            @Param("email") String email,
+            @Param("status") String status,
+            @Param("completedAt") LocalDateTime completedAt
+    );
+
+    /**
+     * 진행률과 마지막 평가 시각을 갱신한다.
+     *
+     * @param challengeId        챌린지 ID
+     * @param email              사용자 이메일
+     * @param progressPercentage 진행률(0.0 ~ 100.0)
+     * @param evaluatedAt        평가 시각
+     * @return 업데이트된 row 수
+     */
+    int updateProgress(
+            @Param("challengeId") Long challengeId,
+            @Param("email") String email,
+            @Param("progressPercentage") Double progressPercentage,
+            @Param("evaluatedAt") LocalDateTime evaluatedAt
+    );
+
+    /**
+     * 챌린지 사전 신청을 취소한다.
+     *
+     * @param challengeId 챌린지 ID
+     * @param email       사용자 이메일
+     * @return 삭제된 row 수
+     */
+    int deleteByChallengeIdAndEmail(
+            @Param("challengeId") Long challengeId,
+            @Param("email") String email
+    );
+}

--- a/src/main/groovy/com/yumyumcoach/domain/challenge/mapper/ChallengeRuleMapper.java
+++ b/src/main/groovy/com/yumyumcoach/domain/challenge/mapper/ChallengeRuleMapper.java
@@ -1,0 +1,21 @@
+package com.yumyumcoach.domain.challenge.mapper;
+
+import com.yumyumcoach.domain.challenge.entity.ChallengeRule;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+@Mapper
+public interface ChallengeRuleMapper {
+
+    /**
+     * 챌린지 + 난이도 기준으로 룰 한 건을 조회한다.
+     *
+     * @param challengeId   챌린지 ID
+     * @param difficultyCode 난이도 코드 (BEGINNER / INTERMEDIATE / ADVANCED)
+     */
+    ChallengeRule findByChallengeIdAndDifficulty(
+            @Param("challengeId") Long challengeId,
+            @Param("difficultyCode") String difficultyCode
+    );
+}
+

--- a/src/main/groovy/com/yumyumcoach/domain/challenge/model/DifficultyCode.java
+++ b/src/main/groovy/com/yumyumcoach/domain/challenge/model/DifficultyCode.java
@@ -1,0 +1,15 @@
+package com.yumyumcoach.domain.challenge.model;
+
+public enum DifficultyCode {
+    BEGINNER,      // 초급
+    INTERMEDIATE,  // 중급
+    ADVANCED;      // 고급
+
+    public static DifficultyCode from(String value) {
+        return DifficultyCode.valueOf(value);
+    }
+
+    public String getCode() {
+        return this.name();
+    }
+}

--- a/src/main/groovy/com/yumyumcoach/domain/challenge/model/GoalType.java
+++ b/src/main/groovy/com/yumyumcoach/domain/challenge/model/GoalType.java
@@ -1,0 +1,15 @@
+package com.yumyumcoach.domain.challenge.model;
+
+public enum GoalType {
+    DAY_COUNT_SIMPLE,        // 이달 N일 이상 기록
+    PROTEIN_PER_DAY,         // 하루 단백질 Xg 이상인 날 N일 이상
+    EXERCISE_MINUTES_PER_DAY; // 하루 운동 Y분 이상인 날 N일 이상
+
+    public static GoalType from(String value) {
+        return GoalType.valueOf(value);
+    }
+
+    public String getCode() {
+        return this.name();
+    }
+}

--- a/src/main/resources/mapper/challenge/ChallengeMapper.xml
+++ b/src/main/resources/mapper/challenge/ChallengeMapper.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.yumyumcoach.domain.challenge.mapper.ChallengeMapper">
+
+    <!-- 공용 챌린지 매핑 -->
+    <resultMap id="ChallengeResultMap" type="com.yumyumcoach.domain.challenge.entity.Challenge">
+        <id     property="id"               column="id"/>
+        <result property="rewardTitleId"    column="reward_title_id"/>
+        <result property="name"             column="name"/>
+        <result property="shortDescription" column="short_description"/>
+        <result property="difficultyCode"   column="difficulty_code"/>
+        <result property="goalSummary"      column="goal_summary"/>
+        <result property="ruleDescription"  column="rule_description"/>
+        <result property="typeCode"         column="type_code"/>
+        <result property="imageUrl"         column="image_url"/>
+        <result property="recruitStartDate" column="recruit_start_date"/>
+        <result property="recruitEndDate"   column="recruit_end_date"/>
+        <result property="startDate"        column="start_date"/>
+        <result property="endDate"          column="end_date"/>
+        <result property="isActive"         column="is_active"/>
+        <result property="goalType"         column="goal_type"/>
+    </resultMap>
+
+    <!-- 특정 기간에 시작되는 챌린지 목록 조회 -->
+    <select id="findByPeriod" resultMap="ChallengeResultMap">
+        SELECT id,
+               reward_title_id,
+               name,
+               short_description,
+               difficulty_code,
+               goal_summary,
+               rule_description,
+               type_code,
+               image_url,
+               recruit_start_date,
+               recruit_end_date,
+               start_date,
+               end_date,
+               is_active,
+               goal_type
+        FROM challenges
+        WHERE start_date BETWEEN #{startDate} AND #{endDate}
+          AND is_active = 1
+        ORDER BY start_date, id
+    </select>
+
+    <!-- 챌린지 단일 조회 -->
+    <select id="findById" resultMap="ChallengeResultMap">
+        SELECT
+            id,
+            reward_title_id,
+            name,
+            short_description,
+            difficulty_code,
+            goal_summary,
+            rule_description,
+            type_code,
+            image_url,
+            recruit_start_date,
+            recruit_end_date,
+            start_date,
+            end_date,
+            is_active,
+            goal_type
+        FROM challenges
+        WHERE id = #{challengeId}
+    </select>
+
+    <!-- 챌린지 참여 인원 수 조회 -->
+    <select id="countParticipants" resultType="int">
+        SELECT COUNT(*)
+        FROM challenge_participants
+        WHERE challenge_id = #{challengeId}
+    </select>
+
+</mapper>

--- a/src/main/resources/mapper/challenge/ChallengeMapper.xml
+++ b/src/main/resources/mapper/challenge/ChallengeMapper.xml
@@ -11,11 +11,10 @@
         <result property="rewardTitleId"    column="reward_title_id"/>
         <result property="name"             column="name"/>
         <result property="shortDescription" column="short_description"/>
-        <result property="difficultyCode"   column="difficulty_code"/>
         <result property="goalSummary"      column="goal_summary"/>
         <result property="ruleDescription"  column="rule_description"/>
-        <result property="typeCode"         column="type_code"/>
         <result property="imageUrl"         column="image_url"/>
+        <result property="challengeType"    column="challenge_type"/>
         <result property="recruitStartDate" column="recruit_start_date"/>
         <result property="recruitEndDate"   column="recruit_end_date"/>
         <result property="startDate"        column="start_date"/>
@@ -30,11 +29,10 @@
                reward_title_id,
                name,
                short_description,
-               difficulty_code,
                goal_summary,
                rule_description,
-               type_code,
                image_url,
+               challenge_type,
                recruit_start_date,
                recruit_end_date,
                start_date,
@@ -54,11 +52,10 @@
             reward_title_id,
             name,
             short_description,
-            difficulty_code,
             goal_summary,
             rule_description,
-            type_code,
             image_url,
+            challenge_type,
             recruit_start_date,
             recruit_end_date,
             start_date,

--- a/src/main/resources/mapper/challenge/ChallengeParticipantMapper.xml
+++ b/src/main/resources/mapper/challenge/ChallengeParticipantMapper.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.yumyumcoach.domain.challenge.mapper.ChallengeParticipantMapper">
+
+    <!-- 공용 챌린지 참여 매핑 -->
+    <resultMap id="ChallengeParticipantResultMap"
+               type="com.yumyumcoach.domain.challenge.entity.ChallengeParticipant">
+        <id     property="challengeId"        column="challenge_id"/>
+        <id     property="email"              column="email"/>
+        <result property="joinedAt"           column="joined_at"/>
+        <result property="status"             column="status"/>
+        <result property="difficultyCode"     column="difficulty_code"/>
+        <result property="requiredSuccessDays" column="required_success_days"/>
+        <result property="dailyTargetValue"   column="daily_target_value"/>
+        <result property="progressPercentage" column="progress_percentage"/>
+        <result property="lastEvaluatedAt"    column="last_evaluated_at"/>
+        <result property="completedAt"        column="completed_at"/>
+    </resultMap>
+
+    <!-- 챌린지 + 이메일로 참여 정보 조회 -->
+    <select id="findByChallengeIdAndEmail"
+            resultMap="ChallengeParticipantResultMap">
+        SELECT
+            challenge_id,
+            email,
+            joined_at,
+            status,
+            difficulty_code,
+            required_success_days,
+            daily_target_value,
+            progress_percentage,
+            last_evaluated_at,
+            completed_at
+        FROM challenge_participants
+        WHERE challenge_id = #{challengeId}
+          AND email = #{email}
+    </select>
+
+    <!-- 이미 참여 중인지 여부 확인 -->
+    <select id="existsByChallengeIdAndEmail" resultType="int">
+        SELECT COUNT(*)
+        FROM challenge_participants
+        WHERE challenge_id = #{challengeId}
+          AND email = #{email}
+    </select>
+
+    <!-- 새로운 참여 정보 추가 -->
+    <insert id="insert" parameterType="com.yumyumcoach.domain.challenge.entity.ChallengeParticipant">
+        INSERT INTO challenge_participants (
+            challenge_id,
+            email,
+            joined_at,
+            status,
+            difficulty_code,
+            required_success_days,
+            daily_target_value,
+            progress_percentage,
+            last_evaluated_at,
+            completed_at
+        ) VALUES (
+                     #{challengeId},
+                     #{email},
+                     #{joinedAt},
+                     #{status},
+                     #{difficultyCode},
+                     #{requiredSuccessDays},
+                     #{dailyTargetValue},
+                     #{progressPercentage},
+                     #{lastEvaluatedAt},
+                     #{completedAt}
+                 )
+    </insert>
+
+    <!-- 참여 상태 변경 (completed / left 등) -->
+    <update id="updateStatus">
+        UPDATE challenge_participants
+        SET status = #{status},
+            completed_at = #{completedAt}
+        WHERE challenge_id = #{challengeId}
+          AND email = #{email}
+    </update>
+
+    <!-- 진행률 및 마지막 평가 시각 갱신 -->
+    <update id="updateProgress">
+        UPDATE challenge_participants
+        SET progress_percentage = #{progressPercentage},
+            last_evaluated_at = #{evaluatedAt}
+        WHERE challenge_id = #{challengeId}
+          AND email = #{email}
+    </update>
+
+    <!-- 참여 정보 삭제 -->
+    <delete id="deleteByChallengeIdAndEmail">
+        DELETE FROM challenge_participants
+        WHERE challenge_id = #{challengeId}
+          AND email = #{email}
+    </delete>
+
+</mapper>

--- a/src/main/resources/mapper/challenge/ChallengeParticipantMapper.xml
+++ b/src/main/resources/mapper/challenge/ChallengeParticipantMapper.xml
@@ -32,6 +32,7 @@
             required_success_days,
             daily_target_value,
             progress_percentage,
+            success_days,
             last_evaluated_at,
             completed_at
         FROM challenge_participants
@@ -58,6 +59,7 @@
             required_success_days,
             daily_target_value,
             progress_percentage,
+            success_days,
             last_evaluated_at,
             completed_at
         ) VALUES (
@@ -69,6 +71,7 @@
                      #{requiredSuccessDays},
                      #{dailyTargetValue},
                      #{progressPercentage},
+                     #{successDays},
                      #{lastEvaluatedAt},
                      #{completedAt}
                  )

--- a/src/main/resources/mapper/challenge/ChallengeRuleMapper.xml
+++ b/src/main/resources/mapper/challenge/ChallengeRuleMapper.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.yumyumcoach.domain.challenge.mapper.ChallengeRuleMapper">
+
+    <resultMap id="ChallengeRuleResultMap"
+               type="com.yumyumcoach.domain.challenge.entity.ChallengeRule">
+        <id     property="challengeId"        column="challenge_id"/>
+        <id     property="difficultyCode"     column="difficulty_code"/>
+        <result property="requiredSuccessDays" column="required_success_days"/>
+        <result property="dailyTargetValue"   column="daily_target_value"/>
+    </resultMap>
+
+    <select id="findByChallengeIdAndDifficulty"
+            resultMap="ChallengeRuleResultMap">
+        SELECT
+            challenge_id,
+            difficulty_code,
+            required_success_days,
+            daily_target_value
+        FROM challenge_rules
+        WHERE challenge_id = #{challengeId}
+          AND difficulty_code = #{difficultyCode}
+    </select>
+
+</mapper>


### PR DESCRIPTION
## 🔗 관련 이슈

> closes #28  

## ✨ 작업 내용

- challenge 관련 DB 스키마 수정
  - 컬럼 추가 및 제거, challenge_rules 테이블 추가
- 챌린지 엔티티 / 매퍼 수정
- 챌린지 룰 전용 엔티티/매퍼 추가
  - ChallengeRule 엔티티 추가, ChallengeRuleMapper 인터페이스 및 xml 추가
  - ChallengeRuleResolver에서 challenge_rules 기반으로 난이도별 룰 해석
- success_days 컬럼, 엔티티, DTO, mapper에 추가
- Challenge API 명세서 수정

## 📌 참고 사항

> 챌린지별로 성공 일수를 계산하는 로직은 별도 이슈에서 진행할 예정

