### PR TITLE
feat(#21): challenge service 및 api 테스트 완료

### DIFF
--- a/src/main/groovy/com/yumyumcoach/domain/challenge/controller/ChallengeController.java
+++ b/src/main/groovy/com/yumyumcoach/domain/challenge/controller/ChallengeController.java
@@ -1,0 +1,70 @@
+package com.yumyumcoach.domain.challenge.controller;
+
+import com.yumyumcoach.domain.challenge.dto.ChallengeListResponse;
+import com.yumyumcoach.domain.challenge.dto.ChallengeResponse;
+import com.yumyumcoach.domain.challenge.dto.JoinChallengeRequest;
+import com.yumyumcoach.domain.challenge.dto.JoinChallengeResponse;
+import com.yumyumcoach.domain.challenge.dto.LeaveChallengeResponse;
+import com.yumyumcoach.domain.challenge.service.ChallengeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * Challenge 관련 컨트롤러.
+ * - /api/challenges 하위 엔드포인트 담당
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/challenges")
+public class ChallengeController {
+
+    private final ChallengeService challengeService;
+
+    /**
+     * 챌린지 목록 조회
+     * 예) GET /api/challenges?month=2025-12
+     */
+    @GetMapping
+    public ChallengeListResponse getChallenges(@RequestParam("month") String month) {
+        String loginUserEmail = "todo@example.com"; // TODO: 인증 연동 후 교체
+        return challengeService.getChallenges(month, loginUserEmail);
+    }
+
+    /**
+     * 개별 챌린지 상세 조회
+     * 예) GET /api/challenges/{challengeId}
+     */
+    @GetMapping("/{challengeId}")
+    public ChallengeResponse getChallengeDetail(@PathVariable("challengeId") Long challengeId) {
+        String loginUserEmail = "todo@example.com"; // TODO: 인증 연동 후 교체
+        return challengeService.getChallengeDetail(challengeId, loginUserEmail);
+    }
+
+    /**
+     * 챌린지 참여 (사전 신청 포함)
+     * 예) POST /api/challenges/{challengeId}/join
+     */
+    @PostMapping("/{challengeId}/join")
+    @ResponseStatus(HttpStatus.CREATED)
+    public JoinChallengeResponse joinChallenge(
+            @PathVariable("challengeId") Long challengeId,
+            @RequestBody JoinChallengeRequest request
+    ) {
+        String loginUserEmail = "todo@example.com"; // TODO: 인증 연동 후 교체
+        return challengeService.joinChallenge(challengeId, loginUserEmail, request);
+    }
+
+    /**
+     * 챌린지 나가기
+     * - 시작 전: 사전신청 취소
+     * - 시작 후: 중도 탈퇴 (status = left)
+     * 예) DELETE /api/challenges/{challengeId}/leave
+     */
+    @DeleteMapping("/{challengeId}/leave")
+    public LeaveChallengeResponse leaveChallenge(@PathVariable("challengeId") Long challengeId) {
+        String loginUserEmail = "todo@example.com"; // TODO: 인증 연동 후 교체
+        return challengeService.leaveChallenge(challengeId, loginUserEmail);
+    }
+}
+

--- a/src/main/groovy/com/yumyumcoach/domain/challenge/mapper/ChallengeParticipantMapper.java
+++ b/src/main/groovy/com/yumyumcoach/domain/challenge/mapper/ChallengeParticipantMapper.java
@@ -83,4 +83,13 @@ public interface ChallengeParticipantMapper {
             @Param("challengeId") Long challengeId,
             @Param("email") String email
     );
+
+    /**
+     * 특정 챌린지에 참여한 전체 인원 수를 조회한다.
+     *
+     * @param challengeId 챌린지 ID
+     * @return 참여 인원 수
+     */
+    int countByChallengeId(@Param("challengeId") Long challengeId);
+
 }

--- a/src/main/groovy/com/yumyumcoach/domain/challenge/service/ChallengeParticipantService.java
+++ b/src/main/groovy/com/yumyumcoach/domain/challenge/service/ChallengeParticipantService.java
@@ -1,0 +1,80 @@
+package com.yumyumcoach.domain.challenge.service;
+
+import com.yumyumcoach.domain.challenge.entity.Challenge;
+import com.yumyumcoach.domain.challenge.entity.ChallengeParticipant;
+import com.yumyumcoach.domain.challenge.mapper.ChallengeMapper;
+import com.yumyumcoach.domain.challenge.mapper.ChallengeParticipantMapper;
+import com.yumyumcoach.domain.challenge.model.GoalType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+/**
+ * 챌린지 참여자 관련 비즈니스 로직을 담당하는 서비스.
+ * 진행률 / 성공 일수 평가 (successDays, progressPercentage 갱신)
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ChallengeParticipantService {
+    private final ChallengeMapper challengeMapper;
+    private final ChallengeParticipantMapper challengeParticipantMapper;
+
+    /**
+     * 특정 챌린지에 참여 중인 한 명의 사용자의 진행률을 재평가한다.
+     * TODO: successDays 계산 쿼리/로직 구현하기
+     *
+     * @param challengeId 챌린지 ID
+     * @param email       사용자 이메일
+     */
+    @Transactional
+    public void evaluateProgress(Long challengeId, String email) {
+        // 1) 챌린지 / 참여 정보 조회
+        Challenge challenge = challengeMapper.findById(challengeId);
+        if (challenge == null) {
+            // TODO: 커스텀 예외로 교체
+            throw new IllegalArgumentException("존재하지 않는 챌린지입니다. id=" + challengeId);
+        }
+
+        ChallengeParticipant participant = challengeParticipantMapper.findByChallengeIdAndEmail(challengeId, email);
+        if (participant == null) {
+            // TODO: 커스텀 예외로 교체
+            throw new IllegalStateException("참여 이력이 없는 챌린지입니다.");
+        }
+
+        // 2) 목표 타입에 따라 분기 (실제 쿼리/계산은 다음 이슈에서 구현)
+        GoalType goalType = GoalType.from(challenge.getGoalType());
+
+        // TODO: goalType / participant 정보에 따라 successDays / progressPercentage 계산
+        // int successDays = ...
+        // double progress = ...
+
+        // 지금은 껍데기만, 실제 값은 다음 이슈에서 구현
+        // 일단 0으로 초기화 예시만 넣어둔다.
+        int successDays = participant.getSuccessDays() != null ? participant.getSuccessDays() : 0;
+        double progress = participant.getProgressPercentage() != null
+                ? participant.getProgressPercentage()
+                : 0.0;
+
+        LocalDateTime now = LocalDateTime.now();
+
+        // 3) 엔티티에 반영
+        participant.updateProgress(successDays, progress, now);
+
+        // 4. DB 반영
+        // 현재 Mapper 에는 successDays 까지 함께 업데이트하는 메서드가 없으므로
+        // 이 부분은 다음 이슈에서 함께 정의할 예정.
+        //
+        // 예시:
+        // challengeParticipantMapper.updateProgressAndSuccessDays(
+        //         challengeId,
+        //         email,
+        //         successDays,
+        //         progress,
+        //         now
+        // );
+    }
+}
+

--- a/src/main/groovy/com/yumyumcoach/domain/challenge/service/ChallengeRuleResolver.java
+++ b/src/main/groovy/com/yumyumcoach/domain/challenge/service/ChallengeRuleResolver.java
@@ -1,0 +1,74 @@
+package com.yumyumcoach.domain.challenge.service;
+
+import com.yumyumcoach.domain.challenge.entity.Challenge;
+import com.yumyumcoach.domain.challenge.entity.ChallengeRule;
+import com.yumyumcoach.domain.challenge.mapper.ChallengeRuleMapper;
+import com.yumyumcoach.domain.challenge.model.DifficultyCode;
+import com.yumyumcoach.domain.challenge.model.GoalType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+/**
+ * challenge_rules 테이블을 기반으로
+ * 챌린지 + 난이도별 룰(최소 성공 일수, 하루 목표값)을 해석하는 헬퍼.
+ */
+@Component
+@RequiredArgsConstructor
+public class ChallengeRuleResolver {
+    private final ChallengeRuleMapper challengeRuleMapper;
+
+    /**
+     * 최소 성공 일수를 조회한다.
+     *
+     * @param challenge     챌린지 엔티티
+     * @param difficultyCode 난이도 코드
+     * @return 최소 성공 일수
+     */
+    public int resolveRequiredSuccessDays(Challenge challenge, DifficultyCode difficultyCode) {
+        ChallengeRule rule = challengeRuleMapper.findByChallengeIdAndDifficulty(
+                challenge.getId(),
+                difficultyCode.getCode()
+        );
+        if (rule == null) {
+            // TODO: 공통 예외로 교체
+            throw new IllegalStateException("챌린지 룰이 설정되지 않았습니다. challengeId="
+                    + challenge.getId() + ", difficulty=" + difficultyCode.getCode());
+        }
+        return rule.getRequiredSuccessDays();
+    }
+
+    /**
+     * 하루 목표값을 조회한다.
+     *
+     * @param challenge     챌린지 엔티티
+     * @param goalType      목표 타입
+     * @param difficultyCode 난이도 코드
+     * @return 하루 목표값 (단순 일수 기준이면 null)
+     */
+    public Double resolveDailyTargetValue(Challenge challenge, GoalType goalType, DifficultyCode difficultyCode) {
+        // DAY_COUNT_SIMPLE 은 "기록만 있으면 1일 인정"이라 별도의 dailyTargetValue 없음
+        if (goalType == GoalType.DAY_COUNT_SIMPLE) {
+            return null;
+        }
+
+        ChallengeRule rule = challengeRuleMapper.findByChallengeIdAndDifficulty(
+                challenge.getId(),
+                difficultyCode.getCode()
+        );
+
+        if (rule == null) {
+            // TODO: 공통 예외로 교체
+            throw new IllegalStateException("챌린지 룰이 설정되지 않았습니다. challengeId="
+                    + challenge.getId() + ", difficulty=" + difficultyCode.getCode());
+        }
+
+        Double value = rule.getDailyTargetValue();
+        if (value == null) {
+            // PROTEIN_PER_DAY, EXERCISE_MINUTES_PER_DAY 등인데 값이 없으면 설정 누락으로 간주
+            throw new IllegalStateException("하루 목표값이 설정되지 않았습니다. challengeId="
+                    + challenge.getId() + ", difficulty=" + difficultyCode.getCode()
+                    + ", goalType=" + goalType.getCode());
+        }
+        return value;
+    }
+}

--- a/src/main/groovy/com/yumyumcoach/domain/challenge/service/ChallengeService.java
+++ b/src/main/groovy/com/yumyumcoach/domain/challenge/service/ChallengeService.java
@@ -1,0 +1,271 @@
+package com.yumyumcoach.domain.challenge.service;
+
+import com.yumyumcoach.domain.challenge.dto.*;
+import com.yumyumcoach.domain.challenge.entity.Challenge;
+import com.yumyumcoach.domain.challenge.entity.ChallengeParticipant;
+import com.yumyumcoach.domain.challenge.mapper.ChallengeMapper;
+import com.yumyumcoach.domain.challenge.mapper.ChallengeParticipantMapper;
+import com.yumyumcoach.domain.challenge.model.DifficultyCode;
+import com.yumyumcoach.domain.challenge.model.GoalType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 공용 챌린지 도메인 서비스.
+ * 챌린지 목록/상세 조회, 참여/나가기 등을 담당한다.
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ChallengeService {
+    private final ChallengeMapper challengeMapper;
+    private final ChallengeParticipantMapper challengeParticipantMapper;
+    private final ChallengeRuleResolver challengeRuleResolver;
+
+    /**
+     * 특정 월 기준 챌린지 목록을 조회한다.
+     *
+     * @param month yyyy-MM 형식의 조회 기준 월
+     * @param email 현재 로그인한 사용자 이메일
+     */
+    public ChallengeListResponse getChallenges(String month, String email) {
+        YearMonth yearMonth = YearMonth.parse(month);
+        LocalDate startDate = yearMonth.atDay(1);
+        LocalDate endDate = yearMonth.atEndOfMonth();
+
+        // 이번 달(월말인 경우 다음 달 포함) 챌린지 조회
+        List<Challenge> challenges = challengeMapper.findByPeriod(startDate, endDate);
+
+        List<ChallengeResponse> challengeResponses = challenges.stream()
+                .map(challenge -> toChallengeResponseForList(challenge, email))
+                .toList();
+
+        return ChallengeListResponse.builder()
+                .month(month)
+                .challenges(challengeResponses)
+                .build();
+    }
+
+    /**
+     * 챌린지 상세 정보를 조회한다.
+     *
+     * @param challengeId 챌린지 ID
+     * @param email       현재 로그인한 사용자 이메일
+     */
+    public ChallengeResponse getChallengeDetail(Long challengeId, String email) {
+        Challenge challenge = challengeMapper.findById(challengeId);
+        if (challenge == null) {
+            // TODO: 커스텀 예외로 교체
+            throw new IllegalArgumentException("존재하지 않는 챌린지입니다. id=" + challengeId);
+        }
+
+        ChallengeParticipant participant = challengeParticipantMapper.findByChallengeIdAndEmail(challengeId, email);
+        return toChallengeResponseForDetail(challenge, participant);
+    }
+
+    /**
+     * 챌린지에 참여(사전 신청 포함)한다.
+     * - challenge_participants 에 어떤 형태로든 참여 이력이 있으면 재참여를 허용하지 않는다.
+     * @param challengeId 챌린지 ID
+     * @param email       현재 로그인한 사용자 이메일
+     * @param request     참여 요청 (난이도 포함)
+     */
+    @Transactional
+    public JoinChallengeResponse joinChallenge(Long challengeId, String email, JoinChallengeRequest request) {
+        // 1) 챌린지 존재 여부 확인
+        Challenge challenge = challengeMapper.findById(challengeId);
+        if (challenge == null) {
+            // TODO: 커스텀 예외로 교체
+            throw new IllegalArgumentException("존재하지 않는 챌린지입니다. id=" + challengeId);
+        }
+
+        // 2) 이미 참여 중인지 체크
+        int existing = challengeParticipantMapper.existsByChallengeIdAndEmail(challengeId, email);
+        if (existing > 0) {
+            // TODO: 커스텀 예외로 교체
+            throw new IllegalStateException("이미 참여 중인 챌린지입니다.");
+        }
+
+        // 3) 난이도 및 목표 타입 결정
+        DifficultyCode difficultyCode = DifficultyCode.from(request.getDifficultyCode());
+        GoalType goalType = GoalType.from(challenge.getGoalType());
+
+        // 4) 챌린지 룰 조회
+        int requiredSuccessDays = challengeRuleResolver.resolveRequiredSuccessDays(challenge, difficultyCode);
+        Double dailyTargetValue = challengeRuleResolver.resolveDailyTargetValue(challenge, goalType, difficultyCode);
+
+        // 5) 참여 엔티티 생성 및 저장
+        ChallengeParticipant participant = ChallengeParticipant.newJoin(
+                challengeId,
+                email,
+                difficultyCode.getCode(),
+                requiredSuccessDays,
+                dailyTargetValue
+        );
+
+        // 6) DB에 저장
+        challengeParticipantMapper.insert(participant);
+
+        LocalDate myStartDate = challenge.getStartDate();
+        LocalDate myEndDate = challenge.getEndDate();
+
+        // 7) 응답 DTO 생성
+        return JoinChallengeResponse.builder()
+                .challengeId(challenge.getId())
+                .title(challenge.getName())
+                .joined(true)
+                .joinedAt(participant.getJoinedAt().toString())
+                .difficultyCode(difficultyCode.getCode())
+                .requiredSuccessDays(requiredSuccessDays)
+                .dailyTargetValue(dailyTargetValue)
+                .myStartDate(myStartDate.toString())
+                .myEndDate(myEndDate.toString())
+                .build();
+    }
+
+    /**
+     * 챌린지를 나간다.
+     * - today < startDate : 사전 신청 취소 → row DELETE
+     * - today >= startDate : 중도 탈퇴 → status = 'left' 로 변경
+     * - 이미 status = 'left' 인 경우 → "이미 나간 챌린지입니다." 에러
+     * @param challengeId 챌린지 ID
+     * @param email       현재 로그인한 사용자 이메일
+     */
+    @Transactional
+    public LeaveChallengeResponse leaveChallenge(Long challengeId, String email) {
+        // 1) 챌린지 존재 여부 확인
+        Challenge challenge = challengeMapper.findById(challengeId);
+        if (challenge == null) {
+            // TODO: 커스텀 예외로 교체
+            throw new IllegalArgumentException("존재하지 않는 챌린지입니다. id=" + challengeId);
+        }
+
+        // 2) 참여중이지 않은지 체크
+        ChallengeParticipant existing = challengeParticipantMapper.findByChallengeIdAndEmail(challengeId, email);
+        if (existing == null) {
+            // TODO: 커스텀 예외로 교체
+            throw new IllegalStateException("참여 이력이 없는 챌린지입니다.");
+        }
+        if ("left".equalsIgnoreCase(existing.getStatus())) {
+            // TODO: 커스텀 예외로 교체
+            throw new IllegalStateException("이미 나간 챌린지입니다.");
+        }
+
+        // 3) 챌린지 시작 전 -> 사전 신청 취소 -> row 삭제 / 챌린지 시작 후 → 중도 탈퇴 → status = 'left' 로 변경
+        LocalDate today = LocalDate.now();
+        boolean isBeforeStart = today.isBefore(challenge.getStartDate());
+        LocalDateTime leftAt = LocalDateTime.now();
+        if (isBeforeStart) {
+            challengeParticipantMapper.deleteByChallengeIdAndEmail(challengeId, email);
+        } else {
+            existing.leave(leftAt);
+            challengeParticipantMapper.updateStatus(challengeId, email, "left", leftAt);
+        }
+
+        // 4) 응답 DTO 생성
+        return LeaveChallengeResponse.builder()
+                .challengeId(challengeId)
+                .left(true)
+                .leftAt(leftAt.toString())
+                .build();
+    }
+
+    /**
+     * 목록 조회용 ChallengeResponse 변환.
+     * - ruleDescription 등 상세 화면에서만 필요한 값은 null 로 둔다.
+     */
+    private ChallengeResponse toChallengeResponseForList(Challenge challenge, String email) {
+        ChallengeParticipant participant =
+                challengeParticipantMapper.findByChallengeIdAndEmail(challenge.getId(), email);
+
+        int participantsCount = challengeParticipantMapper.countByChallengeId(challenge.getId());
+
+        Integer successDays = null;
+        Double progressPercentage = null;
+        String selectedDifficulty = null;
+        Integer requiredSuccessDays = null;
+        Double dailyTargetValue = null;
+        boolean isJoined = false;
+
+        if (participant != null && !"left".equalsIgnoreCase(participant.getStatus())) {
+            isJoined = true;
+            successDays = participant.getSuccessDays();
+            progressPercentage = participant.getProgressPercentage();
+            selectedDifficulty = participant.getDifficultyCode();
+            requiredSuccessDays = participant.getRequiredSuccessDays();
+            dailyTargetValue = participant.getDailyTargetValue();
+        }
+
+        return ChallengeResponse.builder()
+                .challengeId(challenge.getId())
+                .title(challenge.getName())
+                .shortDescription(challenge.getShortDescription())
+                .goalSummary(challenge.getGoalSummary())
+                .ruleDescription(null) // 목록에서는 유의 사항은 내려주지 않음
+                .imageUrl(challenge.getImageUrl())
+                .type(challenge.getChallengeType())
+                .goalType(challenge.getGoalType())
+                .startDate(challenge.getStartDate().toString())
+                .endDate(challenge.getEndDate().toString())
+                .participantsCount(participantsCount)
+                .isJoined(isJoined)
+                .selectedDifficulty(selectedDifficulty)
+                .requiredSuccessDays(requiredSuccessDays)
+                .dailyTargetValue(dailyTargetValue)
+                .successDays(successDays)
+                .progressPercentage(progressPercentage)
+                .build();
+    }
+
+    /**
+     * 상세 조회용 ChallengeResponse 변환.
+     * - ruleDescription 포함, 참여 정보도 함께 내려준다.
+     */
+    private ChallengeResponse toChallengeResponseForDetail(Challenge challenge,
+                                                           ChallengeParticipant participant) {
+        int participantsCount = challengeParticipantMapper.countByChallengeId(challenge.getId());
+
+        Integer successDays = null;
+        Double progressPercentage = null;
+        String selectedDifficulty = null;
+        Integer requiredSuccessDays = null;
+        Double dailyTargetValue = null;
+        boolean isJoined = false;
+
+        if (participant != null && !"left".equalsIgnoreCase(participant.getStatus())) {
+            isJoined = true;
+            successDays = participant.getSuccessDays();
+            progressPercentage = participant.getProgressPercentage();
+            selectedDifficulty = participant.getDifficultyCode();
+            requiredSuccessDays = participant.getRequiredSuccessDays();
+            dailyTargetValue = participant.getDailyTargetValue();
+        }
+
+        return ChallengeResponse.builder()
+                .challengeId(challenge.getId())
+                .title(challenge.getName())
+                .shortDescription(challenge.getShortDescription())
+                .goalSummary(challenge.getGoalSummary())
+                .ruleDescription(challenge.getRuleDescription())
+                .imageUrl(challenge.getImageUrl())
+                .type(challenge.getChallengeType())
+                .goalType(challenge.getGoalType())
+                .startDate(challenge.getStartDate().toString())
+                .endDate(challenge.getEndDate().toString())
+                .participantsCount(participantsCount)
+                .isJoined(isJoined)
+                .selectedDifficulty(selectedDifficulty)
+                .requiredSuccessDays(requiredSuccessDays)
+                .dailyTargetValue(dailyTargetValue)
+                .successDays(successDays)
+                .progressPercentage(progressPercentage)
+                .build();
+    }
+}

--- a/src/main/resources/mapper/challenge/ChallengeMapper.xml
+++ b/src/main/resources/mapper/challenge/ChallengeMapper.xml
@@ -14,13 +14,13 @@
         <result property="goalSummary"      column="goal_summary"/>
         <result property="ruleDescription"  column="rule_description"/>
         <result property="imageUrl"         column="image_url"/>
-        <result property="challengeType"    column="challenge_type"/>
         <result property="recruitStartDate" column="recruit_start_date"/>
         <result property="recruitEndDate"   column="recruit_end_date"/>
         <result property="startDate"        column="start_date"/>
         <result property="endDate"          column="end_date"/>
         <result property="isActive"         column="is_active"/>
         <result property="goalType"         column="goal_type"/>
+        <result property="challengeType"    column="challenge_type"/>
     </resultMap>
 
     <!-- 특정 기간에 시작되는 챌린지 목록 조회 -->
@@ -32,13 +32,13 @@
                goal_summary,
                rule_description,
                image_url,
-               challenge_type,
                recruit_start_date,
                recruit_end_date,
                start_date,
                end_date,
                is_active,
-               goal_type
+               goal_type,
+               challenge_type
         FROM challenges
         WHERE start_date BETWEEN #{startDate} AND #{endDate}
           AND is_active = 1
@@ -55,13 +55,13 @@
             goal_summary,
             rule_description,
             image_url,
-            challenge_type,
             recruit_start_date,
             recruit_end_date,
             start_date,
             end_date,
             is_active,
-            goal_type
+            goal_type,
+            challenge_type
         FROM challenges
         WHERE id = #{challengeId}
     </select>

--- a/src/main/resources/mapper/challenge/ChallengeParticipantMapper.xml
+++ b/src/main/resources/mapper/challenge/ChallengeParticipantMapper.xml
@@ -102,4 +102,11 @@
           AND email = #{email}
     </delete>
 
+    <!-- 특정 챌린지에 참여한 전체 인원 수 조회 -->
+    <select id="countByChallengeId" resultType="int">
+        SELECT COUNT(*)
+        FROM challenge_participants
+        WHERE challenge_id = #{challengeId}
+    </select>
+
 </mapper>


### PR DESCRIPTION
## 🔗 관련 이슈

- #21 

## ✨ 작업 내용

- 특정 챌린지에 참여한 전체 인원 수 조회 로직 추가 (mapper interface/xml)
- ChallengeService 전반적인 로직 구현
- postman으로 api 테스트 완료

## 📌 참고 사항

- auth 쪽 완료 후 인증/인가 적용 예정
- 이후 예외처리 로직 순으로 진행할 예정
<img width="183" height="138" alt="image" src="https://github.com/user-attachments/assets/fe7025da-df12-43ad-b78a-dc0b7867cbdc" />

-  [테스트 방법 정리](https://www.notion.so/dreamgirl11/API-2c84788e596280acab87c50f853896ac)