### PR TITLE
feat(#21): community, challenge 도메인 예외 처리 적용

### DIFF
--- a/src/main/groovy/com/yumyumcoach/domain/challenge/controller/ChallengeController.java
+++ b/src/main/groovy/com/yumyumcoach/domain/challenge/controller/ChallengeController.java
@@ -1,0 +1,70 @@
+package com.yumyumcoach.domain.challenge.controller;
+
+import com.yumyumcoach.domain.challenge.dto.ChallengeListResponse;
+import com.yumyumcoach.domain.challenge.dto.ChallengeResponse;
+import com.yumyumcoach.domain.challenge.dto.JoinChallengeRequest;
+import com.yumyumcoach.domain.challenge.dto.JoinChallengeResponse;
+import com.yumyumcoach.domain.challenge.dto.LeaveChallengeResponse;
+import com.yumyumcoach.domain.challenge.service.ChallengeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * Challenge 관련 컨트롤러.
+ * - /api/challenges 하위 엔드포인트 담당
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/challenges")
+public class ChallengeController {
+
+    private final ChallengeService challengeService;
+
+    /**
+     * 챌린지 목록 조회
+     * 예) GET /api/challenges?month=2025-12
+     */
+    @GetMapping
+    public ChallengeListResponse getChallenges(@RequestParam("month") String month) {
+        String loginUserEmail = "todo@example.com"; // TODO: 인증 연동 후 교체
+        return challengeService.getChallenges(month, loginUserEmail);
+    }
+
+    /**
+     * 개별 챌린지 상세 조회
+     * 예) GET /api/challenges/{challengeId}
+     */
+    @GetMapping("/{challengeId}")
+    public ChallengeResponse getChallengeDetail(@PathVariable("challengeId") Long challengeId) {
+        String loginUserEmail = "todo@example.com"; // TODO: 인증 연동 후 교체
+        return challengeService.getChallengeDetail(challengeId, loginUserEmail);
+    }
+
+    /**
+     * 챌린지 참여 (사전 신청 포함)
+     * 예) POST /api/challenges/{challengeId}/join
+     */
+    @PostMapping("/{challengeId}/join")
+    @ResponseStatus(HttpStatus.CREATED)
+    public JoinChallengeResponse joinChallenge(
+            @PathVariable("challengeId") Long challengeId,
+            @RequestBody JoinChallengeRequest request
+    ) {
+        String loginUserEmail = "todo@example.com"; // TODO: 인증 연동 후 교체
+        return challengeService.joinChallenge(challengeId, loginUserEmail, request);
+    }
+
+    /**
+     * 챌린지 나가기
+     * - 시작 전: 사전신청 취소
+     * - 시작 후: 중도 탈퇴 (status = left)
+     * 예) DELETE /api/challenges/{challengeId}/leave
+     */
+    @DeleteMapping("/{challengeId}/leave")
+    public LeaveChallengeResponse leaveChallenge(@PathVariable("challengeId") Long challengeId) {
+        String loginUserEmail = "todo@example.com"; // TODO: 인증 연동 후 교체
+        return challengeService.leaveChallenge(challengeId, loginUserEmail);
+    }
+}
+

--- a/src/main/groovy/com/yumyumcoach/domain/challenge/mapper/ChallengeParticipantMapper.java
+++ b/src/main/groovy/com/yumyumcoach/domain/challenge/mapper/ChallengeParticipantMapper.java
@@ -83,4 +83,13 @@ public interface ChallengeParticipantMapper {
             @Param("challengeId") Long challengeId,
             @Param("email") String email
     );
+
+    /**
+     * 특정 챌린지에 참여한 전체 인원 수를 조회한다.
+     *
+     * @param challengeId 챌린지 ID
+     * @return 참여 인원 수
+     */
+    int countByChallengeId(@Param("challengeId") Long challengeId);
+
 }

--- a/src/main/groovy/com/yumyumcoach/domain/challenge/service/ChallengeParticipantService.java
+++ b/src/main/groovy/com/yumyumcoach/domain/challenge/service/ChallengeParticipantService.java
@@ -1,0 +1,80 @@
+package com.yumyumcoach.domain.challenge.service;
+
+import com.yumyumcoach.domain.challenge.entity.Challenge;
+import com.yumyumcoach.domain.challenge.entity.ChallengeParticipant;
+import com.yumyumcoach.domain.challenge.mapper.ChallengeMapper;
+import com.yumyumcoach.domain.challenge.mapper.ChallengeParticipantMapper;
+import com.yumyumcoach.domain.challenge.model.GoalType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+/**
+ * 챌린지 참여자 관련 비즈니스 로직을 담당하는 서비스.
+ * 진행률 / 성공 일수 평가 (successDays, progressPercentage 갱신)
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ChallengeParticipantService {
+    private final ChallengeMapper challengeMapper;
+    private final ChallengeParticipantMapper challengeParticipantMapper;
+
+    /**
+     * 특정 챌린지에 참여 중인 한 명의 사용자의 진행률을 재평가한다.
+     * TODO: successDays 계산 쿼리/로직 구현하기
+     *
+     * @param challengeId 챌린지 ID
+     * @param email       사용자 이메일
+     */
+    @Transactional
+    public void evaluateProgress(Long challengeId, String email) {
+        // 1) 챌린지 / 참여 정보 조회
+        Challenge challenge = challengeMapper.findById(challengeId);
+        if (challenge == null) {
+            // TODO: 커스텀 예외로 교체
+            throw new IllegalArgumentException("존재하지 않는 챌린지입니다. id=" + challengeId);
+        }
+
+        ChallengeParticipant participant = challengeParticipantMapper.findByChallengeIdAndEmail(challengeId, email);
+        if (participant == null) {
+            // TODO: 커스텀 예외로 교체
+            throw new IllegalStateException("참여 이력이 없는 챌린지입니다.");
+        }
+
+        // 2) 목표 타입에 따라 분기 (실제 쿼리/계산은 다음 이슈에서 구현)
+        GoalType goalType = GoalType.from(challenge.getGoalType());
+
+        // TODO: goalType / participant 정보에 따라 successDays / progressPercentage 계산
+        // int successDays = ...
+        // double progress = ...
+
+        // 지금은 껍데기만, 실제 값은 다음 이슈에서 구현
+        // 일단 0으로 초기화 예시만 넣어둔다.
+        int successDays = participant.getSuccessDays() != null ? participant.getSuccessDays() : 0;
+        double progress = participant.getProgressPercentage() != null
+                ? participant.getProgressPercentage()
+                : 0.0;
+
+        LocalDateTime now = LocalDateTime.now();
+
+        // 3) 엔티티에 반영
+        participant.updateProgress(successDays, progress, now);
+
+        // 4. DB 반영
+        // 현재 Mapper 에는 successDays 까지 함께 업데이트하는 메서드가 없으므로
+        // 이 부분은 다음 이슈에서 함께 정의할 예정.
+        //
+        // 예시:
+        // challengeParticipantMapper.updateProgressAndSuccessDays(
+        //         challengeId,
+        //         email,
+        //         successDays,
+        //         progress,
+        //         now
+        // );
+    }
+}
+

--- a/src/main/groovy/com/yumyumcoach/domain/challenge/service/ChallengeRuleResolver.java
+++ b/src/main/groovy/com/yumyumcoach/domain/challenge/service/ChallengeRuleResolver.java
@@ -1,0 +1,74 @@
+package com.yumyumcoach.domain.challenge.service;
+
+import com.yumyumcoach.domain.challenge.entity.Challenge;
+import com.yumyumcoach.domain.challenge.entity.ChallengeRule;
+import com.yumyumcoach.domain.challenge.mapper.ChallengeRuleMapper;
+import com.yumyumcoach.domain.challenge.model.DifficultyCode;
+import com.yumyumcoach.domain.challenge.model.GoalType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+/**
+ * challenge_rules 테이블을 기반으로
+ * 챌린지 + 난이도별 룰(최소 성공 일수, 하루 목표값)을 해석하는 헬퍼.
+ */
+@Component
+@RequiredArgsConstructor
+public class ChallengeRuleResolver {
+    private final ChallengeRuleMapper challengeRuleMapper;
+
+    /**
+     * 최소 성공 일수를 조회한다.
+     *
+     * @param challenge     챌린지 엔티티
+     * @param difficultyCode 난이도 코드
+     * @return 최소 성공 일수
+     */
+    public int resolveRequiredSuccessDays(Challenge challenge, DifficultyCode difficultyCode) {
+        ChallengeRule rule = challengeRuleMapper.findByChallengeIdAndDifficulty(
+                challenge.getId(),
+                difficultyCode.getCode()
+        );
+        if (rule == null) {
+            // TODO: 공통 예외로 교체
+            throw new IllegalStateException("챌린지 룰이 설정되지 않았습니다. challengeId="
+                    + challenge.getId() + ", difficulty=" + difficultyCode.getCode());
+        }
+        return rule.getRequiredSuccessDays();
+    }
+
+    /**
+     * 하루 목표값을 조회한다.
+     *
+     * @param challenge     챌린지 엔티티
+     * @param goalType      목표 타입
+     * @param difficultyCode 난이도 코드
+     * @return 하루 목표값 (단순 일수 기준이면 null)
+     */
+    public Double resolveDailyTargetValue(Challenge challenge, GoalType goalType, DifficultyCode difficultyCode) {
+        // DAY_COUNT_SIMPLE 은 "기록만 있으면 1일 인정"이라 별도의 dailyTargetValue 없음
+        if (goalType == GoalType.DAY_COUNT_SIMPLE) {
+            return null;
+        }
+
+        ChallengeRule rule = challengeRuleMapper.findByChallengeIdAndDifficulty(
+                challenge.getId(),
+                difficultyCode.getCode()
+        );
+
+        if (rule == null) {
+            // TODO: 공통 예외로 교체
+            throw new IllegalStateException("챌린지 룰이 설정되지 않았습니다. challengeId="
+                    + challenge.getId() + ", difficulty=" + difficultyCode.getCode());
+        }
+
+        Double value = rule.getDailyTargetValue();
+        if (value == null) {
+            // PROTEIN_PER_DAY, EXERCISE_MINUTES_PER_DAY 등인데 값이 없으면 설정 누락으로 간주
+            throw new IllegalStateException("하루 목표값이 설정되지 않았습니다. challengeId="
+                    + challenge.getId() + ", difficulty=" + difficultyCode.getCode()
+                    + ", goalType=" + goalType.getCode());
+        }
+        return value;
+    }
+}

--- a/src/main/groovy/com/yumyumcoach/domain/challenge/service/ChallengeService.java
+++ b/src/main/groovy/com/yumyumcoach/domain/challenge/service/ChallengeService.java
@@ -7,6 +7,8 @@ import com.yumyumcoach.domain.challenge.mapper.ChallengeMapper;
 import com.yumyumcoach.domain.challenge.mapper.ChallengeParticipantMapper;
 import com.yumyumcoach.domain.challenge.model.DifficultyCode;
 import com.yumyumcoach.domain.challenge.model.GoalType;
+import com.yumyumcoach.global.error.BusinessException;
+import com.yumyumcoach.global.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -14,7 +16,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.YearMonth;
-import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -62,8 +63,7 @@ public class ChallengeService {
     public ChallengeResponse getChallengeDetail(Long challengeId, String email) {
         Challenge challenge = challengeMapper.findById(challengeId);
         if (challenge == null) {
-            // TODO: 커스텀 예외로 교체
-            throw new IllegalArgumentException("존재하지 않는 챌린지입니다. id=" + challengeId);
+            throw new BusinessException(ErrorCode.CHALLENGE_NOT_FOUND);
         }
 
         ChallengeParticipant participant = challengeParticipantMapper.findByChallengeIdAndEmail(challengeId, email);
@@ -82,15 +82,13 @@ public class ChallengeService {
         // 1) 챌린지 존재 여부 확인
         Challenge challenge = challengeMapper.findById(challengeId);
         if (challenge == null) {
-            // TODO: 커스텀 예외로 교체
-            throw new IllegalArgumentException("존재하지 않는 챌린지입니다. id=" + challengeId);
+            throw new BusinessException(ErrorCode.CHALLENGE_NOT_FOUND);
         }
 
         // 2) 이미 참여 중인지 체크
         int existing = challengeParticipantMapper.existsByChallengeIdAndEmail(challengeId, email);
         if (existing > 0) {
-            // TODO: 커스텀 예외로 교체
-            throw new IllegalStateException("이미 참여 중인 챌린지입니다.");
+            throw new BusinessException(ErrorCode.CHALLENGE_ALREADY_JOINED);
         }
 
         // 3) 난이도 및 목표 타입 결정
@@ -143,19 +141,16 @@ public class ChallengeService {
         // 1) 챌린지 존재 여부 확인
         Challenge challenge = challengeMapper.findById(challengeId);
         if (challenge == null) {
-            // TODO: 커스텀 예외로 교체
-            throw new IllegalArgumentException("존재하지 않는 챌린지입니다. id=" + challengeId);
+            throw new BusinessException(ErrorCode.CHALLENGE_NOT_FOUND);
         }
 
         // 2) 참여중이지 않은지 체크
         ChallengeParticipant existing = challengeParticipantMapper.findByChallengeIdAndEmail(challengeId, email);
         if (existing == null) {
-            // TODO: 커스텀 예외로 교체
-            throw new IllegalStateException("참여 이력이 없는 챌린지입니다.");
+            throw new BusinessException(ErrorCode.CHALLENGE_JOIN_NOT_FOUND);
         }
         if ("left".equalsIgnoreCase(existing.getStatus())) {
-            // TODO: 커스텀 예외로 교체
-            throw new IllegalStateException("이미 나간 챌린지입니다.");
+            throw new BusinessException(ErrorCode.CHALLENGE_ALREADY_LEFT);
         }
 
         // 3) 챌린지 시작 전 -> 사전 신청 취소 -> row 삭제 / 챌린지 시작 후 → 중도 탈퇴 → status = 'left' 로 변경

--- a/src/main/groovy/com/yumyumcoach/domain/challenge/service/ChallengeService.java
+++ b/src/main/groovy/com/yumyumcoach/domain/challenge/service/ChallengeService.java
@@ -1,0 +1,271 @@
+package com.yumyumcoach.domain.challenge.service;
+
+import com.yumyumcoach.domain.challenge.dto.*;
+import com.yumyumcoach.domain.challenge.entity.Challenge;
+import com.yumyumcoach.domain.challenge.entity.ChallengeParticipant;
+import com.yumyumcoach.domain.challenge.mapper.ChallengeMapper;
+import com.yumyumcoach.domain.challenge.mapper.ChallengeParticipantMapper;
+import com.yumyumcoach.domain.challenge.model.DifficultyCode;
+import com.yumyumcoach.domain.challenge.model.GoalType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 공용 챌린지 도메인 서비스.
+ * 챌린지 목록/상세 조회, 참여/나가기 등을 담당한다.
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ChallengeService {
+    private final ChallengeMapper challengeMapper;
+    private final ChallengeParticipantMapper challengeParticipantMapper;
+    private final ChallengeRuleResolver challengeRuleResolver;
+
+    /**
+     * 특정 월 기준 챌린지 목록을 조회한다.
+     *
+     * @param month yyyy-MM 형식의 조회 기준 월
+     * @param email 현재 로그인한 사용자 이메일
+     */
+    public ChallengeListResponse getChallenges(String month, String email) {
+        YearMonth yearMonth = YearMonth.parse(month);
+        LocalDate startDate = yearMonth.atDay(1);
+        LocalDate endDate = yearMonth.atEndOfMonth();
+
+        // 이번 달(월말인 경우 다음 달 포함) 챌린지 조회
+        List<Challenge> challenges = challengeMapper.findByPeriod(startDate, endDate);
+
+        List<ChallengeResponse> challengeResponses = challenges.stream()
+                .map(challenge -> toChallengeResponseForList(challenge, email))
+                .toList();
+
+        return ChallengeListResponse.builder()
+                .month(month)
+                .challenges(challengeResponses)
+                .build();
+    }
+
+    /**
+     * 챌린지 상세 정보를 조회한다.
+     *
+     * @param challengeId 챌린지 ID
+     * @param email       현재 로그인한 사용자 이메일
+     */
+    public ChallengeResponse getChallengeDetail(Long challengeId, String email) {
+        Challenge challenge = challengeMapper.findById(challengeId);
+        if (challenge == null) {
+            // TODO: 커스텀 예외로 교체
+            throw new IllegalArgumentException("존재하지 않는 챌린지입니다. id=" + challengeId);
+        }
+
+        ChallengeParticipant participant = challengeParticipantMapper.findByChallengeIdAndEmail(challengeId, email);
+        return toChallengeResponseForDetail(challenge, participant);
+    }
+
+    /**
+     * 챌린지에 참여(사전 신청 포함)한다.
+     * - challenge_participants 에 어떤 형태로든 참여 이력이 있으면 재참여를 허용하지 않는다.
+     * @param challengeId 챌린지 ID
+     * @param email       현재 로그인한 사용자 이메일
+     * @param request     참여 요청 (난이도 포함)
+     */
+    @Transactional
+    public JoinChallengeResponse joinChallenge(Long challengeId, String email, JoinChallengeRequest request) {
+        // 1) 챌린지 존재 여부 확인
+        Challenge challenge = challengeMapper.findById(challengeId);
+        if (challenge == null) {
+            // TODO: 커스텀 예외로 교체
+            throw new IllegalArgumentException("존재하지 않는 챌린지입니다. id=" + challengeId);
+        }
+
+        // 2) 이미 참여 중인지 체크
+        int existing = challengeParticipantMapper.existsByChallengeIdAndEmail(challengeId, email);
+        if (existing > 0) {
+            // TODO: 커스텀 예외로 교체
+            throw new IllegalStateException("이미 참여 중인 챌린지입니다.");
+        }
+
+        // 3) 난이도 및 목표 타입 결정
+        DifficultyCode difficultyCode = DifficultyCode.from(request.getDifficultyCode());
+        GoalType goalType = GoalType.from(challenge.getGoalType());
+
+        // 4) 챌린지 룰 조회
+        int requiredSuccessDays = challengeRuleResolver.resolveRequiredSuccessDays(challenge, difficultyCode);
+        Double dailyTargetValue = challengeRuleResolver.resolveDailyTargetValue(challenge, goalType, difficultyCode);
+
+        // 5) 참여 엔티티 생성 및 저장
+        ChallengeParticipant participant = ChallengeParticipant.newJoin(
+                challengeId,
+                email,
+                difficultyCode.getCode(),
+                requiredSuccessDays,
+                dailyTargetValue
+        );
+
+        // 6) DB에 저장
+        challengeParticipantMapper.insert(participant);
+
+        LocalDate myStartDate = challenge.getStartDate();
+        LocalDate myEndDate = challenge.getEndDate();
+
+        // 7) 응답 DTO 생성
+        return JoinChallengeResponse.builder()
+                .challengeId(challenge.getId())
+                .title(challenge.getName())
+                .joined(true)
+                .joinedAt(participant.getJoinedAt().toString())
+                .difficultyCode(difficultyCode.getCode())
+                .requiredSuccessDays(requiredSuccessDays)
+                .dailyTargetValue(dailyTargetValue)
+                .myStartDate(myStartDate.toString())
+                .myEndDate(myEndDate.toString())
+                .build();
+    }
+
+    /**
+     * 챌린지를 나간다.
+     * - today < startDate : 사전 신청 취소 → row DELETE
+     * - today >= startDate : 중도 탈퇴 → status = 'left' 로 변경
+     * - 이미 status = 'left' 인 경우 → "이미 나간 챌린지입니다." 에러
+     * @param challengeId 챌린지 ID
+     * @param email       현재 로그인한 사용자 이메일
+     */
+    @Transactional
+    public LeaveChallengeResponse leaveChallenge(Long challengeId, String email) {
+        // 1) 챌린지 존재 여부 확인
+        Challenge challenge = challengeMapper.findById(challengeId);
+        if (challenge == null) {
+            // TODO: 커스텀 예외로 교체
+            throw new IllegalArgumentException("존재하지 않는 챌린지입니다. id=" + challengeId);
+        }
+
+        // 2) 참여중이지 않은지 체크
+        ChallengeParticipant existing = challengeParticipantMapper.findByChallengeIdAndEmail(challengeId, email);
+        if (existing == null) {
+            // TODO: 커스텀 예외로 교체
+            throw new IllegalStateException("참여 이력이 없는 챌린지입니다.");
+        }
+        if ("left".equalsIgnoreCase(existing.getStatus())) {
+            // TODO: 커스텀 예외로 교체
+            throw new IllegalStateException("이미 나간 챌린지입니다.");
+        }
+
+        // 3) 챌린지 시작 전 -> 사전 신청 취소 -> row 삭제 / 챌린지 시작 후 → 중도 탈퇴 → status = 'left' 로 변경
+        LocalDate today = LocalDate.now();
+        boolean isBeforeStart = today.isBefore(challenge.getStartDate());
+        LocalDateTime leftAt = LocalDateTime.now();
+        if (isBeforeStart) {
+            challengeParticipantMapper.deleteByChallengeIdAndEmail(challengeId, email);
+        } else {
+            existing.leave(leftAt);
+            challengeParticipantMapper.updateStatus(challengeId, email, "left", leftAt);
+        }
+
+        // 4) 응답 DTO 생성
+        return LeaveChallengeResponse.builder()
+                .challengeId(challengeId)
+                .left(true)
+                .leftAt(leftAt.toString())
+                .build();
+    }
+
+    /**
+     * 목록 조회용 ChallengeResponse 변환.
+     * - ruleDescription 등 상세 화면에서만 필요한 값은 null 로 둔다.
+     */
+    private ChallengeResponse toChallengeResponseForList(Challenge challenge, String email) {
+        ChallengeParticipant participant =
+                challengeParticipantMapper.findByChallengeIdAndEmail(challenge.getId(), email);
+
+        int participantsCount = challengeParticipantMapper.countByChallengeId(challenge.getId());
+
+        Integer successDays = null;
+        Double progressPercentage = null;
+        String selectedDifficulty = null;
+        Integer requiredSuccessDays = null;
+        Double dailyTargetValue = null;
+        boolean isJoined = false;
+
+        if (participant != null && !"left".equalsIgnoreCase(participant.getStatus())) {
+            isJoined = true;
+            successDays = participant.getSuccessDays();
+            progressPercentage = participant.getProgressPercentage();
+            selectedDifficulty = participant.getDifficultyCode();
+            requiredSuccessDays = participant.getRequiredSuccessDays();
+            dailyTargetValue = participant.getDailyTargetValue();
+        }
+
+        return ChallengeResponse.builder()
+                .challengeId(challenge.getId())
+                .title(challenge.getName())
+                .shortDescription(challenge.getShortDescription())
+                .goalSummary(challenge.getGoalSummary())
+                .ruleDescription(null) // 목록에서는 유의 사항은 내려주지 않음
+                .imageUrl(challenge.getImageUrl())
+                .type(challenge.getChallengeType())
+                .goalType(challenge.getGoalType())
+                .startDate(challenge.getStartDate().toString())
+                .endDate(challenge.getEndDate().toString())
+                .participantsCount(participantsCount)
+                .isJoined(isJoined)
+                .selectedDifficulty(selectedDifficulty)
+                .requiredSuccessDays(requiredSuccessDays)
+                .dailyTargetValue(dailyTargetValue)
+                .successDays(successDays)
+                .progressPercentage(progressPercentage)
+                .build();
+    }
+
+    /**
+     * 상세 조회용 ChallengeResponse 변환.
+     * - ruleDescription 포함, 참여 정보도 함께 내려준다.
+     */
+    private ChallengeResponse toChallengeResponseForDetail(Challenge challenge,
+                                                           ChallengeParticipant participant) {
+        int participantsCount = challengeParticipantMapper.countByChallengeId(challenge.getId());
+
+        Integer successDays = null;
+        Double progressPercentage = null;
+        String selectedDifficulty = null;
+        Integer requiredSuccessDays = null;
+        Double dailyTargetValue = null;
+        boolean isJoined = false;
+
+        if (participant != null && !"left".equalsIgnoreCase(participant.getStatus())) {
+            isJoined = true;
+            successDays = participant.getSuccessDays();
+            progressPercentage = participant.getProgressPercentage();
+            selectedDifficulty = participant.getDifficultyCode();
+            requiredSuccessDays = participant.getRequiredSuccessDays();
+            dailyTargetValue = participant.getDailyTargetValue();
+        }
+
+        return ChallengeResponse.builder()
+                .challengeId(challenge.getId())
+                .title(challenge.getName())
+                .shortDescription(challenge.getShortDescription())
+                .goalSummary(challenge.getGoalSummary())
+                .ruleDescription(challenge.getRuleDescription())
+                .imageUrl(challenge.getImageUrl())
+                .type(challenge.getChallengeType())
+                .goalType(challenge.getGoalType())
+                .startDate(challenge.getStartDate().toString())
+                .endDate(challenge.getEndDate().toString())
+                .participantsCount(participantsCount)
+                .isJoined(isJoined)
+                .selectedDifficulty(selectedDifficulty)
+                .requiredSuccessDays(requiredSuccessDays)
+                .dailyTargetValue(dailyTargetValue)
+                .successDays(successDays)
+                .progressPercentage(progressPercentage)
+                .build();
+    }
+}

--- a/src/main/groovy/com/yumyumcoach/domain/community/controller/CommentController.java
+++ b/src/main/groovy/com/yumyumcoach/domain/community/controller/CommentController.java
@@ -16,13 +16,19 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 @RequestMapping("/api/posts/{postId}/comments")
 public class CommentController {
-
     private final CommentService commentService;
+
+    // TODO: 인증 연동 후 교체
+    private String mockLoginEmail() {
+        // 자신이 테스트로 db에 등록한 계정
+        return "todo@example.com";
+        // 403 테스트할 땐 다른 계정으로 바꾸고 수정/삭제 호출하면 됨
+    }
 
     // 특정 게시글의 댓글 목록 조회
     @GetMapping
     public GetCommentsResponse getComments(@PathVariable("postId") Long postId) {
-        return commentService.getComments(postId);
+        return commentService.getComments(postId, mockLoginEmail());
     }
 
     // 댓글 작성
@@ -30,8 +36,7 @@ public class CommentController {
     @ResponseStatus(HttpStatus.CREATED)
     public CommentResponse createComment(@PathVariable("postId") Long postId,
                                          @RequestBody CommentRequest request) {
-        Long loginUserId = 1L; // TODO: 인증 연동 후 실제 사용자 ID 주입
-        return commentService.createComment(loginUserId, postId, request);
+        return commentService.createComment(mockLoginEmail(), postId, request);
     }
 
     // 댓글 수정
@@ -39,8 +44,7 @@ public class CommentController {
     public CommentResponse updateComment(@PathVariable("postId") Long postId,
                                          @PathVariable("commentId") Long commentId,
                                          @RequestBody CommentRequest request) {
-        Long loginUserId = 1L; // TODO
-        return commentService.updateComment(loginUserId, postId, commentId, request);
+        return commentService.updateComment(mockLoginEmail(), postId, commentId, request);
     }
 
     // 댓글 삭제
@@ -48,8 +52,7 @@ public class CommentController {
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void deleteComment(@PathVariable("postId") Long postId,
                               @PathVariable("commentId") Long commentId) {
-        Long loginUserId = 1L; // TODO
-        commentService.deleteComment(loginUserId, postId, commentId);
+        commentService.deleteComment(mockLoginEmail(), postId, commentId);
     }
 }
 

--- a/src/main/groovy/com/yumyumcoach/domain/community/controller/CommentController.java
+++ b/src/main/groovy/com/yumyumcoach/domain/community/controller/CommentController.java
@@ -4,6 +4,7 @@ import com.yumyumcoach.domain.community.dto.CommentRequest;
 import com.yumyumcoach.domain.community.dto.CommentResponse;
 import com.yumyumcoach.domain.community.dto.GetCommentsResponse;
 import com.yumyumcoach.domain.community.service.CommentService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
@@ -35,7 +36,7 @@ public class CommentController {
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     public CommentResponse createComment(@PathVariable("postId") Long postId,
-                                         @RequestBody CommentRequest request) {
+                                         @Valid @RequestBody CommentRequest request) {
         return commentService.createComment(mockLoginEmail(), postId, request);
     }
 
@@ -43,7 +44,7 @@ public class CommentController {
     @PutMapping("/{commentId}")
     public CommentResponse updateComment(@PathVariable("postId") Long postId,
                                          @PathVariable("commentId") Long commentId,
-                                         @RequestBody CommentRequest request) {
+                                         @Valid @RequestBody CommentRequest request) {
         return commentService.updateComment(mockLoginEmail(), postId, commentId, request);
     }
 

--- a/src/main/groovy/com/yumyumcoach/domain/community/controller/PostController.java
+++ b/src/main/groovy/com/yumyumcoach/domain/community/controller/PostController.java
@@ -19,56 +19,56 @@ import org.springframework.web.bind.annotation.*;
 public class PostController {
     private final PostService postService;
 
+    // TODO: 인증 연동 후 교체
+    private String mockLoginEmail() {
+        // 자신이 테스트로 db에 등록한 계정
+        return "todo@example.com";
+        // 403 테스트할 땐 다른 계정으로 바꾸고 수정/삭제 호출하면 됨
+    }
+
     // 전체 게시글 목록 조회
     @GetMapping
     public GetPostsResponse getPosts(GetPostsRequest request) {
-        Long loginUserId = 1L; // TODO: 인증 연동 후 교체
-        return postService.getPosts(request, loginUserId);
+        return postService.getPosts(request, mockLoginEmail());
     }
 
     // 게시글 상세 조회
     @GetMapping("/{postId}")
     public PostResponse getPost(@PathVariable("postId") Long postId) {
-        Long loginUserId = 1L; // TODO: 인증 연동 후 교체
-        return postService.getPost(postId, loginUserId);
+        return postService.getPost(postId, mockLoginEmail());
     }
 
     // 게시글 작성
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     public PostResponse post(@RequestBody PostRequest request) {
-        Long loginUserId = 1L; // TODO: 인증 연동 후 교체
-        return postService.createPost(loginUserId, request);
+        return postService.createPost(mockLoginEmail(), request);
     }
 
     // 게시글 수정
     @PutMapping("/{postId}")
     public PostResponse updatePost(@PathVariable("postId") Long postId, @RequestBody PostRequest request) {
-        Long loginUserId = 1L; // TODO: 인증 연동 후 교체
-        return postService.updatePost(loginUserId, postId, request);
+        return postService.updatePost(mockLoginEmail(), postId, request);
     }
 
     // 게시글 삭제
     @DeleteMapping("/{postId}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void deletePost(@PathVariable("postId") Long postId) {
-        Long loginUserId = 1L; // TODO: 인증 연동 후 교체
-        postService.deletePost(loginUserId, postId);
+        postService.deletePost(mockLoginEmail(), postId);
     }
 
     // 게시글 좋아요
     @PostMapping("/{postId}/like")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void likePost(@PathVariable("postId") Long postId) {
-        Long loginUserId = 1L; // TODO: 인증 연동 후 교체
-        postService.likePost(loginUserId, postId);
+        postService.likePost(mockLoginEmail(), postId);
     }
 
     // 게시글 좋아요 취소
     @DeleteMapping("/{postId}/like")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void unlikePost(@PathVariable("postId") Long postId) {
-        Long loginUserId = 1L; // TODO: 인증 연동 후 교체
-        postService.unlikePost(loginUserId, postId);
+        postService.unlikePost(mockLoginEmail(), postId);
     }
 }

--- a/src/main/groovy/com/yumyumcoach/domain/community/controller/PostController.java
+++ b/src/main/groovy/com/yumyumcoach/domain/community/controller/PostController.java
@@ -5,6 +5,7 @@ import com.yumyumcoach.domain.community.dto.GetPostsResponse;
 import com.yumyumcoach.domain.community.dto.PostRequest;
 import com.yumyumcoach.domain.community.dto.PostResponse;
 import com.yumyumcoach.domain.community.service.PostService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
@@ -41,13 +42,13 @@ public class PostController {
     // 게시글 작성
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    public PostResponse post(@RequestBody PostRequest request) {
+    public PostResponse post(@Valid @RequestBody PostRequest request) {
         return postService.createPost(mockLoginEmail(), request);
     }
 
     // 게시글 수정
     @PutMapping("/{postId}")
-    public PostResponse updatePost(@PathVariable("postId") Long postId, @RequestBody PostRequest request) {
+    public PostResponse updatePost(@PathVariable("postId") Long postId, @Valid @RequestBody PostRequest request) {
         return postService.updatePost(mockLoginEmail(), postId, request);
     }
 

--- a/src/main/groovy/com/yumyumcoach/domain/community/dto/CommentRequest.java
+++ b/src/main/groovy/com/yumyumcoach/domain/community/dto/CommentRequest.java
@@ -1,5 +1,7 @@
 package com.yumyumcoach.domain.community.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -19,5 +21,7 @@ public class CommentRequest {
     /**
      * 댓글 내용
      */
+    @NotBlank(message = "댓글 내용은 필수입니다.")
+    @Size(max = 500, message = "댓글은 500자 이하여야 합니다.")
     private String content;
 }

--- a/src/main/groovy/com/yumyumcoach/domain/community/dto/PostRequest.java
+++ b/src/main/groovy/com/yumyumcoach/domain/community/dto/PostRequest.java
@@ -1,5 +1,7 @@
 package com.yumyumcoach.domain.community.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -21,11 +23,15 @@ public class PostRequest {
     /**
      * 게시글 제목
      */
+    @NotBlank(message = "제목은 필수입니다.")
+    @Size(max = 100, message = "제목은 100자 이하여야 합니다.")
     private String title;
 
     /**
      * 게시글 본문
      */
+    @NotBlank(message = "내용은 필수입니다.")
+    @Size(max = 2000, message = "내용은 2000자 이하여야 합니다.")
     private String content;
 
     /**

--- a/src/main/groovy/com/yumyumcoach/domain/community/mapper/PostCommentMapper.java
+++ b/src/main/groovy/com/yumyumcoach/domain/community/mapper/PostCommentMapper.java
@@ -22,4 +22,6 @@ public interface PostCommentMapper {
     void delete(@Param("commentId") Long commentId);
 
     void deleteByPostId(@Param("postId") Long postId);
+
+    PostComment findByIdAndPostId(Long commentId, Long postId);
 }

--- a/src/main/groovy/com/yumyumcoach/domain/community/service/CommentService.java
+++ b/src/main/groovy/com/yumyumcoach/domain/community/service/CommentService.java
@@ -8,6 +8,8 @@ import com.yumyumcoach.domain.community.entity.Post;
 import com.yumyumcoach.domain.community.entity.PostComment;
 import com.yumyumcoach.domain.community.mapper.PostCommentMapper;
 import com.yumyumcoach.domain.community.mapper.PostMapper;
+import com.yumyumcoach.global.error.BusinessException;
+import com.yumyumcoach.global.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -27,16 +29,23 @@ public class CommentService {
     private final PostMapper postMapper;
     private final PostCommentMapper postCommentMapper;
 
+    private void requireEmail(String email) {
+        if (email == null || email.isBlank()) {
+            throw new BusinessException(ErrorCode.AUTH_UNAUTHORIZED);
+        }
+    }
+
     /**
      * 특정 게시글의 댓글 목록 조회
      * - GET /api/posts/{postId}/comments
      */
-    public GetCommentsResponse getComments(Long postId) {
+    public GetCommentsResponse getComments(Long postId, String loginUserEmail) {
+        requireEmail(loginUserEmail);
+
         // 1) 게시글 존재 여부 확인
         Post post = postMapper.findById(postId);
         if (post == null) {
-            // TODO: 커스텀 예외로 교체
-            throw new IllegalArgumentException("해당 게시글을 찾을 수 없습니다. postId=" + postId);
+            throw new BusinessException(ErrorCode.POST_NOT_FOUND, "댓글을 조회할 게시글을 찾을 수 없습니다.");
         }
 
         // 2) 댓글 목록 조회
@@ -69,29 +78,25 @@ public class CommentService {
      * - POST /api/posts/{postId}/comments
      */
     @Transactional
-    public CommentResponse createComment(Long loginUserId, Long postId, CommentRequest request) {
+    public CommentResponse createComment(String loginUserEmail, Long postId, CommentRequest request) {
+        requireEmail(loginUserEmail);
+
         // 1) 게시글 존재 여부 확인
         Post post = postMapper.findById(postId);
         if (post == null) {
-            // TODO: 커스텀 예외로 교체
-            throw new IllegalArgumentException("해당 게시글을 찾을 수 없습니다. postId=" + postId);
+            throw new BusinessException(ErrorCode.POST_NOT_FOUND, "댓글을 작성할 게시글을 찾을 수 없습니다.");
         }
 
-        // 2) 로그인 유저 정보 (User/Auth 연동 전이라 더미 값)
-        // TODO: loginUserId -> email, authorId 변환 (User/Auth 도메인 연동)
-        String authorEmail = "todo@example.com";
-
+        // 2) PostComment 엔티티 생성
         LocalDateTime now = LocalDateTime.now();
-
-        // 3) PostComment 엔티티 생성
         PostComment comment = PostComment.builder()
                 .postId(postId)
-                .authorEmail(authorEmail)
+                .authorEmail(loginUserEmail)
                 .content(request.getContent())
                 .createdAt(now)
                 .build();
 
-        // 4) DB 저장 (id 자동 증가)
+        // 3) DB 저장 (id 자동 증가)
         postCommentMapper.insert(comment); // useGeneratedKeys=true 로 인해 comment.id 세팅됨
 
         return CommentResponse.builder()
@@ -110,31 +115,26 @@ public class CommentService {
      * - PUT /api/posts/{postId}/comments/{commentId}
      */
     @Transactional
-    public CommentResponse updateComment(Long loginUserId, Long postId, Long commentId, CommentRequest request) {
-        // 1) 댓글 조회
-        PostComment existing = postCommentMapper.findById(commentId);
+    public CommentResponse updateComment(String loginUserEmail, Long postId, Long commentId, CommentRequest request) {
+        requireEmail(loginUserEmail);
+
+        // 1) 댓글 조회 (postId와 commentId가 일치하는 댓글을 한 번에 조회)
+        PostComment existing = postCommentMapper.findByIdAndPostId(commentId, postId);
         if (existing == null) {
-            // TODO: 커스텀 예외로 교체
-            throw new IllegalArgumentException("해당 댓글을 찾을 수 없습니다. commentId=" + commentId);
+            throw new BusinessException(ErrorCode.COMMENT_NOT_FOUND, "수정할 댓글을 찾을 수 없습니다.");
         }
 
-        // 2) postId 일치 여부 확인 (URL, DB 불일치 방지)
-        if (!existing.getPostId().equals(postId)) {
-            // TODO: 커스텀 예외로 교체
-            throw new IllegalArgumentException("댓글이 해당 게시글에 속하지 않습니다. postId=" + postId);
+        // 2) 403: 작성자만 수정 가능
+        if (existing.getAuthorEmail() == null ||
+                !existing.getAuthorEmail().equalsIgnoreCase(loginUserEmail)) {
+            throw new BusinessException(ErrorCode.COMMENT_FORBIDDEN);
         }
 
-        // 3) 권한 체크 (작성자 == 로그인 유저인지)
-        // TODO: loginUserId -> email 변환 후 existing.getAuthorEmail() 과 비교
-
-        // 4) 내용 수정
-        LocalDateTime now = LocalDateTime.now();
-        PostComment toUpdate = PostComment.builder()
+        // 3) 내용 수정
+        postCommentMapper.update(PostComment.builder()
                 .id(commentId)
                 .content(request.getContent())
-                .build();
-
-        postCommentMapper.update(toUpdate);
+                .build());
 
         return CommentResponse.builder()
                 .commentId(commentId)
@@ -152,24 +152,22 @@ public class CommentService {
      * - DELETE /api/posts/{postId}/comments/{commentId}
      */
     @Transactional
-    public void deleteComment(Long loginUserId, Long postId, Long commentId) {
+    public void deleteComment(String loginUserEmail, Long postId, Long commentId) {
+        requireEmail(loginUserEmail);
+
         // 1) 댓글 조회
         PostComment existing = postCommentMapper.findById(commentId);
         if (existing == null) {
-            // TODO: 커스텀 예외로 교체
-            return;
+            throw new BusinessException(ErrorCode.COMMENT_NOT_FOUND, "삭제할 댓글을 찾을 수 없습니다.");
         }
 
-        // 2) postId 일치 여부 확인
-        if (!existing.getPostId().equals(postId)) {
-            // TODO: 커스텀 예외로 교체
-            throw new IllegalArgumentException("댓글이 해당 게시글에 속하지 않습니다. postId=" + postId);
+        // 2) 403: 작성자만 삭제 가능
+        if (existing.getAuthorEmail() == null ||
+                !existing.getAuthorEmail().equalsIgnoreCase(loginUserEmail)) {
+            throw new BusinessException(ErrorCode.COMMENT_FORBIDDEN);
         }
 
-        // 3) 권한 체크 (작성자 == 로그인 유저인지)
-        // TODO: loginUserId -> email 변환 후 existing.getAuthorEmail() 비교
-
-        // 4) 삭제
-        postCommentMapper.deleteByPostId(postId);
+        // 3) 해당 댓글 1개만 삭제
+        postCommentMapper.delete(commentId);
     }
 }

--- a/src/main/groovy/com/yumyumcoach/domain/community/service/PostService.java
+++ b/src/main/groovy/com/yumyumcoach/domain/community/service/PostService.java
@@ -11,6 +11,8 @@ import com.yumyumcoach.domain.community.mapper.PostCommentMapper;
 import com.yumyumcoach.domain.community.mapper.PostImageMapper;
 import com.yumyumcoach.domain.community.mapper.PostLikeMapper;
 import com.yumyumcoach.domain.community.mapper.PostMapper;
+import com.yumyumcoach.global.error.BusinessException;
+import com.yumyumcoach.global.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,7 +20,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * Community 게시글 관련 서비스.
@@ -36,11 +37,17 @@ public class PostService {
     private final PostLikeMapper postLikeMapper;
     private final PostCommentMapper postCommentMapper;
 
+    private void requireEmail(String email) {
+        if (email == null || email.isBlank()) {
+            throw new BusinessException(ErrorCode.AUTH_UNAUTHORIZED);
+        }
+    }
+
     /**
      * 전체 게시글 목록(피드) 조회
      * - GET /api/posts
      */
-    public GetPostsResponse getPosts(GetPostsRequest request, Long loginUserId) {
+    public GetPostsResponse getPosts(GetPostsRequest request, String loginUserEmail) {
         // TODO:
         // 1) request.getPage(), request.getSize()를 사용해 페이징 조회
         int page = request.getPage();
@@ -60,9 +67,6 @@ public class PostService {
                     .posts(Collections.emptyList())
                     .build();
         }
-
-        // TODO: loginUserId -> email (User/Auth 도메인 연동 후)
-        String loginUserEmail = (loginUserId != null) ? "todo@example.com" : null;
 
         // 3) Post -> PostResponse 매핑
         List<PostResponse> postResponses = posts.stream()
@@ -114,12 +118,13 @@ public class PostService {
      * 게시글 상세 조회
      * - GET /api/posts/{postId}
      */
-    public PostResponse getPost(Long postId, Long loginUserId) {
+    public PostResponse getPost(Long postId, String loginUserEmail) {
+        requireEmail(loginUserEmail);
+
         // 1) 게시글 조회
         Post post = postMapper.findById(postId);
         if (post == null) {
-            // TODO: 커스텀 예외(PostNotFoundException)로 교체
-            throw new IllegalArgumentException("해당 게시글을 찾을 수 없습니다. postId=" + postId);
+            throw new BusinessException(ErrorCode.POST_NOT_FOUND);
         }
 
         // 2) 이미지 목록 조회
@@ -135,12 +140,7 @@ public class PostService {
         int likeCount = post.getLikes();
 
         // 5) 현재 유저가 좋아요 눌렀는지 여부
-        boolean isLikedByMe = false;
-        if (loginUserId != null) {
-            // TODO: loginUserId -> email 변환 (User/Auth 도메인 연동 후 수정)
-            String loginUserEmail = "todo@example.com";
-            isLikedByMe = postLikeMapper.existsByPostIdAndAuthorEmail(postId, loginUserEmail);
-        }
+        boolean isLikedByMe =  postLikeMapper.existsByPostIdAndAuthorEmail(postId, loginUserEmail);
 
         return PostResponse.builder()
                 .postId(post.getId())
@@ -163,13 +163,12 @@ public class PostService {
      * - POST /api/posts
      */
     @Transactional
-    public PostResponse createPost(Long loginUserId, PostRequest request) {
-        // TODO: loginUserId -> email, authorId 변환 (User/Auth 도메인 연동)
-        String authorEmail = "todo@example.com";
+    public PostResponse createPost(String loginUserEmail, PostRequest request) {
+        requireEmail(loginUserEmail);
 
         // 1) Post 엔티티 생성
         Post post = Post.builder()
-                .authorEmail(authorEmail)
+                .authorEmail(loginUserEmail)
                 .title(request.getTitle())
                 .content(request.getContent())
                 .createdAt(LocalDateTime.now())
@@ -213,15 +212,20 @@ public class PostService {
      * - PUT /api/posts/{postId}
      */
     @Transactional
-    public PostResponse updatePost(Long loginUserId, Long postId, PostRequest request) {
+    public PostResponse updatePost(String loginUserEmail, Long postId, PostRequest request) {
+        requireEmail(loginUserEmail);
+
         // 1) 기존 게시글 조회
         Post existing = postMapper.findById(postId);
         if (existing == null) {
-            // TODO: 커스텀 예외
-            throw new IllegalArgumentException("해당 게시글을 찾을 수 없습니다. postId=" + postId);
+            throw new BusinessException(ErrorCode.POST_NOT_FOUND);
         }
 
-        // TODO: loginUserId -> email 변환 후, 작성자(authorEmail)와 동일한지 체크
+        // 403: 작성자만 수정 가능
+        if (existing.getAuthorEmail() == null ||
+                !existing.getAuthorEmail().equalsIgnoreCase(loginUserEmail)) {
+            throw new BusinessException(ErrorCode.POST_FORBIDDEN);
+        }
 
         // 2) 제목/내용 수정
         Post post = Post.builder()
@@ -246,12 +250,8 @@ public class PostService {
 
         // 4) 댓글 수, 좋아요 수, isLikedByMe 다시 조회
         long commentCount = postCommentMapper.countByPostId(postId);
-        int likeCount = post.getLikes();
-        boolean isLikedByMe = false;
-        if (loginUserId != null) {
-            String loginUserEmail = "todo@example.com"; // TODO
-            isLikedByMe =  postLikeMapper.existsByPostIdAndAuthorEmail(postId, loginUserEmail);
-        }
+        int likeCount = existing.getLikes();
+        boolean isLikedByMe =   postLikeMapper.existsByPostIdAndAuthorEmail(postId, loginUserEmail);
 
         return PostResponse.builder()
                 .postId(postId)
@@ -274,14 +274,19 @@ public class PostService {
      * - DELETE /api/posts/{postId}
      */
     @Transactional
-    public void deletePost(Long loginUserId, Long postId) {
+    public void deletePost(String loginUserEmail, Long postId) {
+        requireEmail(loginUserEmail);
+
         Post existing = postMapper.findById(postId);
         if (existing == null) {
-            // TODO : 커스텀 예외
-            return;
+            throw new BusinessException(ErrorCode.POST_NOT_FOUND);
         }
 
-        // TODO: loginUserId -> email 변환 후, 작성자(authorEmail)와 동일한지 권한 체크
+        // 403: 작성자만 삭제 가능
+        if (existing.getAuthorEmail() == null ||
+                !existing.getAuthorEmail().equalsIgnoreCase(loginUserEmail)) {
+            throw new BusinessException(ErrorCode.POST_FORBIDDEN);
+        }
 
         // 1) 연관 데이터 삭제
         postImageMapper.deleteByPostId(postId);
@@ -297,24 +302,27 @@ public class PostService {
      * - POST /api/posts/{postId}/like
      */
     @Transactional
-    public void likePost(Long loginUserId, Long postId) {
-        // TODO: loginUserId -> email 변환 (User/Auth 도메인 연동)
-        String authorEmail = "todo@example.com";
+    public void likePost(String loginUserEmail, Long postId) {
+        requireEmail(loginUserEmail);
 
-        // 1) 이미 좋아요 눌렀는지 확인
-        boolean alreadyLiked = postLikeMapper.existsByPostIdAndAuthorEmail(postId, authorEmail);
-        if (alreadyLiked) {
-            // TODO: 이미 좋아요인 상태면 커스텀 예외
-            return;
+        // 1) 해당 게시글이 존재하는지 확인
+        Post post = postMapper.findById(postId);
+        if (post == null) {
+            throw new BusinessException(ErrorCode.POST_NOT_FOUND);
         }
 
-        // 2) 좋아요 INSERT
-        PostLike like = PostLike.builder()
+        // 2) 이미 좋아요 눌렀는지 확인
+        boolean alreadyLiked = postLikeMapper.existsByPostIdAndAuthorEmail(postId, loginUserEmail);
+        if (alreadyLiked) {
+            throw new BusinessException(ErrorCode.LIKE_ALREADY_EXISTS, "좋아요를 누를 게시글을 찾을 수 없습니다.");
+        }
+
+        // 3) 좋아요 INSERT
+        postLikeMapper.insert(PostLike.builder()
                 .postId(postId)
-                .authorEmail(authorEmail)
+                .authorEmail(loginUserEmail)
                 .createdAt(LocalDateTime.now())
-                .build();
-        postLikeMapper.insert(like);
+                .build());
 
         // 3) posts.likes +1
         postMapper.increaseLikes(postId);
@@ -325,21 +333,25 @@ public class PostService {
      * - DELETE /api/posts/{postId}/like
      */
     @Transactional
-    public void unlikePost(Long loginUserId, Long postId) {
-        // TODO: loginUserId -> email 변환 (User/Auth 도메인 연동)
-        String authorEmail = "todo@example.com";
+    public void unlikePost(String loginUserEmail, Long postId) {
+        requireEmail(loginUserEmail);
 
-        // 1) 좋아요가 존재하는지 확인
-        boolean alreadyLiked = postLikeMapper.existsByPostIdAndAuthorEmail(postId, authorEmail);
-        if (!alreadyLiked) {
-            // TODO: 이미 좋아요가 아닌 상태면 커스텀 예외
-            return;
+        // 1) 해당 게시글이 존재하는지 확인
+        Post post = postMapper.findById(postId);
+        if (post == null) {
+            throw new BusinessException(ErrorCode.POST_NOT_FOUND, "좋아요를 취소할 게시글을 찾을 수 없습니다.");
         }
 
-        // 2) post_likes 에서 삭제
-        postLikeMapper.deleteByPostIdAndAuthorEmail(postId, authorEmail);
+        // 2) 좋아요가 존재하는지 확인
+        boolean alreadyLiked = postLikeMapper.existsByPostIdAndAuthorEmail(postId, loginUserEmail);
+        if (!alreadyLiked) {
+            throw new BusinessException(ErrorCode.LIKE_NOT_FOUND);
+        }
 
-        // 3) posts.likes -1
+        // 3) post_likes 에서 삭제
+        postLikeMapper.deleteByPostIdAndAuthorEmail(postId, loginUserEmail);
+
+        // 4) posts.likes -1
         postMapper.decreaseLikes(postId);
     }
 }

--- a/src/main/groovy/com/yumyumcoach/global/error/BusinessException.java
+++ b/src/main/groovy/com/yumyumcoach/global/error/BusinessException.java
@@ -1,0 +1,21 @@
+package com.yumyumcoach.global.error;
+
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public BusinessException(ErrorCode errorCode) {
+        super(errorCode.getMessage()); // 기본 메시지
+        this.errorCode = errorCode;
+    }
+
+    // message 오버라이드
+    public BusinessException(ErrorCode errorCode, String messageOverride) {
+        super(messageOverride);
+        this.errorCode = errorCode;
+    }
+}
+

--- a/src/main/groovy/com/yumyumcoach/global/error/ErrorCode.java
+++ b/src/main/groovy/com/yumyumcoach/global/error/ErrorCode.java
@@ -1,0 +1,37 @@
+package com.yumyumcoach.global.error;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+
+    // ===== COMMON =====
+    AUTH_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "액세스 토큰이 유효하지 않습니다."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류가 발생했습니다."),
+    INVALID_REQUEST(HttpStatus.BAD_REQUEST, "요청 값이 올바르지 않습니다."),
+
+    // ===== COMMUNITY =====
+    POST_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 게시글을 찾을 수 없습니다."),
+    POST_FORBIDDEN(HttpStatus.FORBIDDEN, "해당 게시글에 대한 권한이 없습니다."),
+    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 댓글을 찾을 수 없습니다."),
+    COMMENT_FORBIDDEN(HttpStatus.FORBIDDEN, "해당 댓글에 대한 권한이 없습니다."),
+    LIKE_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 좋아요를 누른 게시글입니다."),
+    LIKE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 게시글에 대해 눌러둔 좋아요가 없습니다."),
+
+    // ===== CHALLENGE =====
+    CHALLENGE_INVALID_MONTH_PARAM(HttpStatus.BAD_REQUEST,
+            "조회 월 형식이 올바르지 않습니다."),
+    CHALLENGE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 챌린지를 찾을 수 없습니다."),
+    CHALLENGE_ALREADY_JOINED(HttpStatus.CONFLICT, "이미 참여 중인 챌린지입니다."),
+    CHALLENGE_JOIN_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "현재는 해당 챌린지에 참여할 수 없습니다."),
+    CHALLENGE_JOIN_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 챌린지에 대한 참여 이력을 찾을 수 없습니다."),
+    CHALLENGE_LEAVE_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "현재는 해당 챌린지에서 나갈 수 없습니다."),
+    CHALLENGE_ALREADY_LEFT(HttpStatus.CONFLICT, "이미 나간 챌린지입니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}
+

--- a/src/main/groovy/com/yumyumcoach/global/error/ErrorResponse.java
+++ b/src/main/groovy/com/yumyumcoach/global/error/ErrorResponse.java
@@ -1,0 +1,21 @@
+package com.yumyumcoach.global.error;
+
+public record ErrorResponse(int status, String code, String message) {
+    public static ErrorResponse from(ErrorCode errorCode) {
+        return new ErrorResponse(
+                errorCode.getHttpStatus().value(),
+                errorCode.name(),
+                errorCode.getMessage()
+        );
+    }
+    // message만 바꾸고 싶을 때
+    public static ErrorResponse of(ErrorCode errorCode, String message) {
+        return new ErrorResponse(
+                errorCode.getHttpStatus().value(),
+                errorCode.name(),
+                message
+        );
+    }
+}
+
+

--- a/src/main/groovy/com/yumyumcoach/global/error/GlobalExceptionHandler.java
+++ b/src/main/groovy/com/yumyumcoach/global/error/GlobalExceptionHandler.java
@@ -1,0 +1,42 @@
+package com.yumyumcoach.global.error;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<ErrorResponse> handleBusiness(BusinessException e) {
+        ErrorCode ec = e.getErrorCode();
+        return ResponseEntity.status(ec.getHttpStatus()).body(ErrorResponse.of(ec, e.getMessage()));
+    }
+
+    // @Valid 실패 -> 400
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleValid(MethodArgumentNotValidException e) {
+        return ResponseEntity.badRequest().body(ErrorResponse.from(ErrorCode.INVALID_REQUEST));
+    }
+
+    // JSON 바디가 깨짐/파싱 실패 -> 400
+    @ExceptionHandler(org.springframework.http.converter.HttpMessageNotReadableException.class)
+    public ResponseEntity<ErrorResponse> handleNotReadable(Exception e) {
+        return ResponseEntity.badRequest().body(ErrorResponse.from(ErrorCode.INVALID_REQUEST));
+    }
+
+    // path/query 타입 미스매치 -> 400
+    @ExceptionHandler(org.springframework.web.method.annotation.MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ErrorResponse> handleTypeMismatch(Exception e) {
+        return ResponseEntity.badRequest().body(ErrorResponse.from(ErrorCode.INVALID_REQUEST));
+    }
+
+    // 나머지 -> 500
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleUnknown(Exception e) {
+        return ResponseEntity.status(ErrorCode.INTERNAL_SERVER_ERROR.getHttpStatus())
+                .body(ErrorResponse.from(ErrorCode.INTERNAL_SERVER_ERROR));
+    }
+}
+

--- a/src/main/resources/mapper/challenge/ChallengeMapper.xml
+++ b/src/main/resources/mapper/challenge/ChallengeMapper.xml
@@ -14,13 +14,13 @@
         <result property="goalSummary"      column="goal_summary"/>
         <result property="ruleDescription"  column="rule_description"/>
         <result property="imageUrl"         column="image_url"/>
-        <result property="challengeType"    column="challenge_type"/>
         <result property="recruitStartDate" column="recruit_start_date"/>
         <result property="recruitEndDate"   column="recruit_end_date"/>
         <result property="startDate"        column="start_date"/>
         <result property="endDate"          column="end_date"/>
         <result property="isActive"         column="is_active"/>
         <result property="goalType"         column="goal_type"/>
+        <result property="challengeType"    column="challenge_type"/>
     </resultMap>
 
     <!-- 특정 기간에 시작되는 챌린지 목록 조회 -->
@@ -32,13 +32,13 @@
                goal_summary,
                rule_description,
                image_url,
-               challenge_type,
                recruit_start_date,
                recruit_end_date,
                start_date,
                end_date,
                is_active,
-               goal_type
+               goal_type,
+               challenge_type
         FROM challenges
         WHERE start_date BETWEEN #{startDate} AND #{endDate}
           AND is_active = 1
@@ -55,13 +55,13 @@
             goal_summary,
             rule_description,
             image_url,
-            challenge_type,
             recruit_start_date,
             recruit_end_date,
             start_date,
             end_date,
             is_active,
-            goal_type
+            goal_type,
+            challenge_type
         FROM challenges
         WHERE id = #{challengeId}
     </select>

--- a/src/main/resources/mapper/challenge/ChallengeParticipantMapper.xml
+++ b/src/main/resources/mapper/challenge/ChallengeParticipantMapper.xml
@@ -102,4 +102,11 @@
           AND email = #{email}
     </delete>
 
+    <!-- 특정 챌린지에 참여한 전체 인원 수 조회 -->
+    <select id="countByChallengeId" resultType="int">
+        SELECT COUNT(*)
+        FROM challenge_participants
+        WHERE challenge_id = #{challengeId}
+    </select>
+
 </mapper>

--- a/src/main/resources/mapper/community/PostCommentMapper.xml
+++ b/src/main/resources/mapper/community/PostCommentMapper.xml
@@ -67,4 +67,12 @@
         WHERE post_id = #{postId}
     </delete>
 
+    <!-- 특정 게시글에 해당 하는 댓글 단건 조회 -->
+    <select id="findByIdAndPostId" resultType="com.yumyumcoach.domain.community.entity.PostComment">
+        SELECT *
+        FROM post_comments
+        WHERE id = #{commentId}
+          AND post_id = #{postId}
+    </select>
+
 </mapper>


### PR DESCRIPTION
## 🔗 관련 이슈

> #11 #21 

## ✨ 작업 내용

* Community 도메인 서비스 로직에 `BusinessException(ErrorCode)` 적용
  * 게시글/댓글/좋아요 기능에서 `POST_NOT_FOUND`, `COMMENT_NOT_FOUND`, `COMMENT_FORBIDDEN`, `LIKE_ALREADY_EXISTS`, `LIKE_NOT_FOUND` 처리

* Challenge 도메인 서비스 로직에 `BusinessException(ErrorCode)` 적용
  * 챌린지/참여 이력 조회 실패 및 참여 정책 제한 케이스 예외 처리 적용

* @vaild 적용으로 게시글 작성, 수정, 댓글 작성, 수정 시 잘못된 값이 입력되는 부분 방지

## 📌 참고 사항

* JWT 인증 연동 전이라 **Unauthorized(401)** 는 추후 체크할 예정
* 도메인별 에러 응답 명세는 추후 문서로 정리 예정
