### PR TITLE
feat(#8): login 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 HELP.md
 .gradle
+.env
 build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/

--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,13 @@ dependencies {
     testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:4.0.0'
     runtimeOnly 'com.mysql:mysql-connector-j'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // https://mvnrepository.com/artifact/io.jsonwebtoken/jjwt-api
+    implementation("io.jsonwebtoken:jjwt-api:0.13.0")
+    // https://mvnrepository.com/artifact/io.jsonwebtoken/jjwt-impl
+    runtimeOnly("io.jsonwebtoken:jjwt-impl:0.13.0")
+    // https://mvnrepository.com/artifact/io.jsonwebtoken/jjwt-jackson
+    runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.13.0")
 }
 
 tasks.named('test') {

--- a/src/main/groovy/com/yumyumcoach/domain/auth/controller/AuthController.java
+++ b/src/main/groovy/com/yumyumcoach/domain/auth/controller/AuthController.java
@@ -1,0 +1,27 @@
+package com.yumyumcoach.domain.auth.controller;
+
+import com.yumyumcoach.domain.auth.dto.LoginRequest;
+import com.yumyumcoach.domain.auth.dto.LoginResponse;
+import com.yumyumcoach.domain.auth.service.AuthService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/login")
+    public ResponseEntity<LoginResponse> login(@RequestBody LoginRequest request) {
+
+        LoginResponse response = authService.login(request);
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/groovy/com/yumyumcoach/domain/auth/dto/LoginRequest.java
+++ b/src/main/groovy/com/yumyumcoach/domain/auth/dto/LoginRequest.java
@@ -1,0 +1,15 @@
+package com.yumyumcoach.domain.auth.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/*
+로그인 요청 (email, password)
+ */
+
+@Getter
+@NoArgsConstructor
+public class LoginRequest {
+    private String email;
+    private String password;
+}

--- a/src/main/groovy/com/yumyumcoach/domain/auth/dto/LoginResponse.java
+++ b/src/main/groovy/com/yumyumcoach/domain/auth/dto/LoginResponse.java
@@ -1,0 +1,23 @@
+package com.yumyumcoach.domain.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/*
+로그인 응답 dto
+ */
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class LoginResponse {
+    private String accessToken;
+    private String refreshToken;
+    private String tokenType;
+    private long accessTokenExpiresIn; // access token 만료시간(단위: 밀리초)
+    private long refreshTokenExpiresIn; // refresh token 만료시간(단위: 밀리 초)
+    private UserInfo userInfo;
+}

--- a/src/main/groovy/com/yumyumcoach/domain/auth/dto/UserInfo.java
+++ b/src/main/groovy/com/yumyumcoach/domain/auth/dto/UserInfo.java
@@ -1,0 +1,13 @@
+package com.yumyumcoach.domain.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserInfo {
+    private String email;
+    private String username;
+}

--- a/src/main/groovy/com/yumyumcoach/domain/auth/entity/Account.java
+++ b/src/main/groovy/com/yumyumcoach/domain/auth/entity/Account.java
@@ -1,0 +1,18 @@
+package com.yumyumcoach.domain.auth.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/*
+DB 의 users 와 매핑되는 클래스
+ */
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Account {
+    private String email;
+    private String username;
+    private String password;
+}

--- a/src/main/groovy/com/yumyumcoach/domain/auth/mapper/AccountMapper.java
+++ b/src/main/groovy/com/yumyumcoach/domain/auth/mapper/AccountMapper.java
@@ -1,0 +1,16 @@
+package com.yumyumcoach.domain.auth.mapper;
+
+import com.yumyumcoach.domain.auth.entity.Account;
+import org.apache.ibatis.annotations.Mapper;
+
+/*
+login 로직에서 필요한 email 로 회원찾기
+
+성공 시: 해당 Account 반환
+실패 시: null 반환
+ */
+
+@Mapper
+public interface AccountMapper {
+    Account findByEmail(String email);
+}

--- a/src/main/groovy/com/yumyumcoach/domain/auth/service/AuthService.java
+++ b/src/main/groovy/com/yumyumcoach/domain/auth/service/AuthService.java
@@ -1,0 +1,57 @@
+package com.yumyumcoach.domain.auth.service;
+
+import com.yumyumcoach.domain.auth.dto.LoginRequest;
+import com.yumyumcoach.domain.auth.dto.LoginResponse;
+import com.yumyumcoach.domain.auth.dto.UserInfo;
+import com.yumyumcoach.domain.auth.entity.Account;
+import com.yumyumcoach.domain.auth.mapper.AccountMapper;
+import com.yumyumcoach.global.exception.InvalidCredentialsException;
+import com.yumyumcoach.global.jwt.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/*
+사용자에게 입력받은 이메일과 비밀번호를 검증하고,
+성공 시 JWT 방식의 access token 과 refresh token 생성 후
+
+성공 시: 로그인 정보 반환
+실패 시: InvalidCredentialsException 예외 던짐
+ */
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final AccountMapper accountMapper;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Transactional(readOnly = true)
+    public LoginResponse login(LoginRequest request) {
+        Account account = accountMapper.findByEmail(request.getEmail());
+
+        // 해당 이메일이 DB 에 없을 때
+        if (account == null) {
+            throw new InvalidCredentialsException("등록되지 않은 회원입니다.");
+        }
+        // 이메일은 DB 에 존재하나 비밀번호가 틀렸을 때
+        else if(!passwordEncoder.matches(request.getPassword(), account.getPassword())) {
+            throw new InvalidCredentialsException("비밀번호가 일치하지 않습니다.");
+        }
+
+        //access token 생성, refresh token 생성
+        String accessToken = jwtTokenProvider.createAccessToken(account.getEmail());
+        String refreshToken = jwtTokenProvider.createRefreshToken(account.getEmail());
+
+        return LoginResponse.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .tokenType(jwtTokenProvider.getTokenType())
+                .accessTokenExpiresIn(jwtTokenProvider.getAccessTokenExpirationSeconds())
+                . refreshTokenExpiresIn(jwtTokenProvider.getRefreshTokenExpirationSeconds())
+                .userInfo(new UserInfo(account.getEmail(), account.getUsername()))
+                .build();
+    }
+}

--- a/src/main/groovy/com/yumyumcoach/global/config/SecurityConfig.java
+++ b/src/main/groovy/com/yumyumcoach/global/config/SecurityConfig.java
@@ -5,6 +5,8 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
@@ -16,8 +18,14 @@ public class SecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> auth
                         //  api 테스트를 위해 권한 절차 해제
+                        .requestMatchers("/api/auth/").permitAll()
                         .anyRequest().permitAll()
                 );
         return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
     }
 }

--- a/src/main/groovy/com/yumyumcoach/global/exception/GlobalExceptionHandler.java
+++ b/src/main/groovy/com/yumyumcoach/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,51 @@
+package com.yumyumcoach.global.exception;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.security.SignatureException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/*
+전역 예외
+ */
+
+@RestControllerAdvice
+public class GlobalExceptionHandler extends RuntimeException {
+
+    // JWT: 401 에러
+    @ExceptionHandler({
+            ExpiredJwtException.class,
+            SignatureException.class,
+            MalformedJwtException.class,
+            UnsupportedJwtException.class,
+
+    })
+    public ResponseEntity<?> handleJwtUnauthorized(Exception e) {
+        return createErrorResponse("INVALID_TOKEN", e.getMessage(), 401);
+    }
+
+    // JWT: 400 에러
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<?> handleIllegalArgument(IllegalArgumentException e) {
+        return createErrorResponse("INVALID_TOKEN", e.getMessage(), 400);
+    }
+
+    // JWT: 잘못된 이메일/비밀번호 입력 에러
+    @ExceptionHandler(InvalidCredentialsException.class)
+    public ResponseEntity<?> InvalidCredentialsException(InvalidCredentialsException e) {
+        return createErrorResponse("AUTH_INVALID_CREDENTIALS", e.getMessage(), 401);
+    }
+
+    // 공통 에러 응답
+    private ResponseEntity<?> createErrorResponse(String code, String message, int status) {
+        return ResponseEntity
+                .status(status)
+                .body(Map.of("status", status, "code", code, "message", message));
+    }
+}

--- a/src/main/groovy/com/yumyumcoach/global/exception/InvalidCredentialsException.java
+++ b/src/main/groovy/com/yumyumcoach/global/exception/InvalidCredentialsException.java
@@ -1,0 +1,7 @@
+package com.yumyumcoach.global.exception;
+
+public class InvalidCredentialsException extends RuntimeException{
+    public InvalidCredentialsException(String message) {
+        super(message);
+    }
+}

--- a/src/main/groovy/com/yumyumcoach/global/jwt/JwtTokenProvider.java
+++ b/src/main/groovy/com/yumyumcoach/global/jwt/JwtTokenProvider.java
@@ -1,0 +1,90 @@
+package com.yumyumcoach.global.jwt;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Date;
+
+/*
+    - JWT 생성/검증 담당 도우미 클래스
+    - AccessToken/RefreshToken 만들기
+    - 토큰에서 이메일 같은 클레임 꺼내기
+    - 유효성 검사
+ */
+
+@Component
+public class JwtTokenProvider {
+    private static final String TOKEN_TYPE = "Bearer";
+
+    private final SecretKey key;
+    private final Duration accessTokenExpiration;
+    private final Duration refreshTokenExpiration;
+
+    public JwtTokenProvider(
+            @Value("${jwt.secret}") String secret,
+            @Value("${jwt.access-token-expire-time}") Duration accessExpiration,
+            @Value("${jwt.refresh-token-expire-time}") Duration refreshExpiration
+    ) {
+        this.key = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+        this.accessTokenExpiration = accessExpiration;
+        this.refreshTokenExpiration = refreshExpiration;
+    }
+
+    public String createAccessToken(String email) {
+        return createToken(email, accessTokenExpiration);
+    }
+
+    public String createRefreshToken(String email) {
+        return createToken(email, refreshTokenExpiration);
+    }
+
+    // 토큰 유효성 검사(예외는 전역 예외처리에서 처리)
+    public boolean validateToken(String token) {
+        Jwts.parser()
+                .verifyWith(key)
+                .build()
+                .parseSignedClaims(token);
+        return true;
+    }
+
+    // 토큰에서 이메일 추출
+    public String getEmail(String token) {
+        return Jwts.parser()
+                .verifyWith(key)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload()
+                .getSubject();
+    }
+
+    public String getTokenType() {
+        return TOKEN_TYPE;
+    }
+
+    public long getAccessTokenExpirationSeconds() {
+        return accessTokenExpiration.toSeconds();
+    }
+
+    public long getRefreshTokenExpirationSeconds() {
+        return refreshTokenExpiration.toSeconds();
+    }
+
+    // 토큰 생성 공통 메서드
+    private String createToken(String email, Duration expireTime) {
+        Date now = new Date();
+        Date expiration = Date.from(Instant.now().plus(expireTime));
+
+        return Jwts.builder()
+                .subject(email)
+                .issuedAt(now)
+                .expiration(expiration)
+                .signWith(key)
+                .compact();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,6 +5,7 @@ spring:
 ---
 spring:
   config:
+    import: optional:file:.env[.properties]
     activate:
       on-profile: dev
 
@@ -14,13 +15,18 @@ spring:
     password: ssafy
     driver-class-name: com.mysql.cj.jdbc.Driver
 
+mybatis:
+  mapper-locations: classpath*:mapper/**/*.xml
+  type-aliases-package: com.yumyumcoach.domain
+
+jwt:
+  secret: ${JWT_SECRET}
+  access-token-expire-time: 1h
+  refresh-token-expire-time: 7d
+
 server:
   port: 8080
 
 logging:
   level:
     root: info
-
-mybatis:
-  mapper-locations: classpath*:mapper/**/*.xml
-  type-aliases-package: com.yumyumcoach.domain

--- a/src/main/resources/mapper/auth/AccountMapper.xml
+++ b/src/main/resources/mapper/auth/AccountMapper.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.yumyumcoach.domain.auth.mapper.AccountMapper">
+
+    <select id="findByEmail" resultType="com.yumyumcoach.domain.auth.entity.Account">
+        SELECT email, username, password
+        FROM accounts
+        WHERE email = #{email}
+    </select>
+
+</mapper>


### PR DESCRIPTION
## 🔗 관련 이슈
- #8 

## ✨ 작업 내용
- `/api/auth/login` 구현: 이메일/비밀번호 검증 후 JWT access/refresh 토큰 발급
- JWT 프로바이더 설정: secret 적용, access(1h)/refresh(7d) 만료, 토큰 검증 유틸 추가
- 예외 처리: 미등록/비번 불일치 시 `AUTH_INVALID_CREDENTIALS` 401, 만료/서명 오류 등 JWT 문제 시 `INVALID_TOKEN` 401/400 응답
- 설정 보완: `.env`의 `JWT_SECRET`를 읽도록 `spring.config.import: optional:file:.env[.properties]` 추가

## 📌 참고 사항
- 로컬 실행 전 `JWT_SECRET` 환경변수 또는 `.env`에 값이 필요합니다.(키 값은 노션-문서 페이지 참조)