### PR TITLE
fix(#43): Windows/Mac 인코딩 차이로 인한 한글 깨짐 해결

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.jvmargs=-Dfile.encoding=UTF-8

--- a/src/main/groovy/com/yumyumcoach/domain/auth/mapper/AccountMapper.java
+++ b/src/main/groovy/com/yumyumcoach/domain/auth/mapper/AccountMapper.java
@@ -2,6 +2,7 @@ package com.yumyumcoach.domain.auth.mapper;
 
 import com.yumyumcoach.domain.auth.entity.Account;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 
 /*
 login 로직에서 필요한 email 로 회원찾기
@@ -12,5 +13,5 @@ login 로직에서 필요한 email 로 회원찾기
 
 @Mapper
 public interface AccountMapper {
-    Account findByEmail(String email);
+    Account findByEmail(@Param("email") String email);
 }


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #43 

## ✨ 작업 내용

- Windows 환경에서 Gradle 인코딩 차이로 에러 응답 message 한글 깨짐 발생하여, JVM 인코딩을 UTF-8로 고정했습니다.
- 추가로 MyBatis에서 파라미터 이름이 명시되지 않으면 바인딩 오류가 발생할 수 있어 @Param을 적용했습니다.

## 📌 참고 사항

- 빌드 후 (./gradlew clean build) 한글 정상 출력 확인