### PR TITLE
refactor(#41): 운동 기록 예외처리/검증 + 게시글/댓글 삭제 로직 개선

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.jvmargs=-Dfile.encoding=UTF-8

--- a/src/main/groovy/com/yumyumcoach/domain/auth/mapper/AccountMapper.java
+++ b/src/main/groovy/com/yumyumcoach/domain/auth/mapper/AccountMapper.java
@@ -2,6 +2,7 @@ package com.yumyumcoach.domain.auth.mapper;
 
 import com.yumyumcoach.domain.auth.entity.Account;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 
 /*
 login 로직에서 필요한 email 로 회원찾기
@@ -12,5 +13,5 @@ login 로직에서 필요한 email 로 회원찾기
 
 @Mapper
 public interface AccountMapper {
-    Account findByEmail(String email);
+    Account findByEmail(@Param("email") String email);
 }

--- a/src/main/groovy/com/yumyumcoach/domain/community/controller/CommentController.java
+++ b/src/main/groovy/com/yumyumcoach/domain/community/controller/CommentController.java
@@ -24,7 +24,7 @@ public class CommentController {
     @GetMapping
     public GetCommentsResponse getComments(@PathVariable("postId") Long postId) {
         String email = CurrentUser.email();
-        return commentService.getComments(postId, email);
+        return commentService.getComments(postId);
     }
 
     // 댓글 작성

--- a/src/main/groovy/com/yumyumcoach/domain/community/service/CommentService.java
+++ b/src/main/groovy/com/yumyumcoach/domain/community/service/CommentService.java
@@ -29,19 +29,11 @@ public class CommentService {
     private final PostMapper postMapper;
     private final PostCommentMapper postCommentMapper;
 
-    private void requireEmail(String email) {
-        if (email == null || email.isBlank()) {
-            throw new BusinessException(ErrorCode.AUTH_UNAUTHORIZED);
-        }
-    }
-
     /**
      * 특정 게시글의 댓글 목록 조회
      * - GET /api/posts/{postId}/comments
      */
-    public GetCommentsResponse getComments(Long postId, String loginUserEmail) {
-        requireEmail(loginUserEmail);
-
+    public GetCommentsResponse getComments(Long postId) {
         // 1) 게시글 존재 여부 확인
         Post post = postMapper.findById(postId);
         if (post == null) {
@@ -79,8 +71,6 @@ public class CommentService {
      */
     @Transactional
     public CommentResponse createComment(String loginUserEmail, Long postId, CommentRequest request) {
-        requireEmail(loginUserEmail);
-
         // 1) 게시글 존재 여부 확인
         Post post = postMapper.findById(postId);
         if (post == null) {
@@ -116,8 +106,6 @@ public class CommentService {
      */
     @Transactional
     public CommentResponse updateComment(String loginUserEmail, Long postId, Long commentId, CommentRequest request) {
-        requireEmail(loginUserEmail);
-
         // 1) 댓글 조회 (postId와 commentId가 일치하는 댓글을 한 번에 조회)
         PostComment existing = postCommentMapper.findByIdAndPostId(commentId, postId);
         if (existing == null) {
@@ -153,10 +141,8 @@ public class CommentService {
      */
     @Transactional
     public void deleteComment(String loginUserEmail, Long postId, Long commentId) {
-        requireEmail(loginUserEmail);
-
         // 1) 댓글 조회
-        PostComment existing = postCommentMapper.findById(commentId);
+        PostComment existing = postCommentMapper.findByIdAndPostId(commentId, postId);
         if (existing == null) {
             throw new BusinessException(ErrorCode.COMMENT_NOT_FOUND, "삭제할 댓글을 찾을 수 없습니다.");
         }

--- a/src/main/groovy/com/yumyumcoach/domain/community/service/PostService.java
+++ b/src/main/groovy/com/yumyumcoach/domain/community/service/PostService.java
@@ -37,12 +37,6 @@ public class PostService {
     private final PostLikeMapper postLikeMapper;
     private final PostCommentMapper postCommentMapper;
 
-    private void requireEmail(String email) {
-        if (email == null || email.isBlank()) {
-            throw new BusinessException(ErrorCode.AUTH_UNAUTHORIZED);
-        }
-    }
-
     /**
      * 전체 게시글 목록(피드) 조회
      * - GET /api/posts
@@ -119,8 +113,6 @@ public class PostService {
      * - GET /api/posts/{postId}
      */
     public PostResponse getPost(Long postId, String loginUserEmail) {
-        requireEmail(loginUserEmail);
-
         // 1) 게시글 조회
         Post post = postMapper.findById(postId);
         if (post == null) {
@@ -164,8 +156,6 @@ public class PostService {
      */
     @Transactional
     public PostResponse createPost(String loginUserEmail, PostRequest request) {
-        requireEmail(loginUserEmail);
-
         // 1) Post 엔티티 생성
         Post post = Post.builder()
                 .authorEmail(loginUserEmail)
@@ -213,8 +203,6 @@ public class PostService {
      */
     @Transactional
     public PostResponse updatePost(String loginUserEmail, Long postId, PostRequest request) {
-        requireEmail(loginUserEmail);
-
         // 1) 기존 게시글 조회
         Post existing = postMapper.findById(postId);
         if (existing == null) {
@@ -275,8 +263,6 @@ public class PostService {
      */
     @Transactional
     public void deletePost(String loginUserEmail, Long postId) {
-        requireEmail(loginUserEmail);
-
         Post existing = postMapper.findById(postId);
         if (existing == null) {
             throw new BusinessException(ErrorCode.POST_NOT_FOUND);
@@ -303,8 +289,6 @@ public class PostService {
      */
     @Transactional
     public void likePost(String loginUserEmail, Long postId) {
-        requireEmail(loginUserEmail);
-
         // 1) 해당 게시글이 존재하는지 확인
         Post post = postMapper.findById(postId);
         if (post == null) {
@@ -334,8 +318,6 @@ public class PostService {
      */
     @Transactional
     public void unlikePost(String loginUserEmail, Long postId) {
-        requireEmail(loginUserEmail);
-
         // 1) 해당 게시글이 존재하는지 확인
         Post post = postMapper.findById(postId);
         if (post == null) {

--- a/src/main/groovy/com/yumyumcoach/domain/exercise/controller/MyExerciseRecordController.java
+++ b/src/main/groovy/com/yumyumcoach/domain/exercise/controller/MyExerciseRecordController.java
@@ -4,9 +4,14 @@ import com.yumyumcoach.domain.exercise.dto.DeleteExerciseRecordResponse;
 import com.yumyumcoach.domain.exercise.dto.ExerciseRecordRequest;
 import com.yumyumcoach.domain.exercise.dto.ExerciseRecordResponse;
 import com.yumyumcoach.domain.exercise.service.ExerciseService;
+import com.yumyumcoach.global.common.CurrentUser;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
@@ -14,42 +19,51 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
+@Validated
 @RequestMapping("/api/me/exercise-records")
 public class MyExerciseRecordController {
     private final ExerciseService exerciseService;
 
     @GetMapping
     public List<ExerciseRecordResponse> getMyExerciseRecords(
-            @RequestParam("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate recordDate
+            @RequestParam("date")
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate recordDate
     ) {
-        String loginUserEmail = "todo@example.com"; // TODO: 인증 연동 후 교체
-        return exerciseService.getMyExerciseRecords(loginUserEmail, recordDate);
+        String email = CurrentUser.email();
+        return exerciseService.getMyExerciseRecords(email, recordDate);
     }
 
     @GetMapping("/{recordId}")
-    public ExerciseRecordResponse getMyExerciseRecordDetail(@PathVariable("recordId") Long recordId) {
-        String loginUserEmail = "todo@example.com"; // TODO: 인증 연동 후 교체
-        return exerciseService.getMyExerciseRecordDetail(loginUserEmail, recordId);
+    public ExerciseRecordResponse getMyExerciseRecordDetail(
+            @PathVariable("recordId") @Positive Long recordId
+    ) {
+        String email = CurrentUser.email();
+        return exerciseService.getMyExerciseRecordDetail(email, recordId);
     }
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    public List<ExerciseRecordResponse> createMyExerciseRecord(@RequestBody List<ExerciseRecordRequest> requests) {
-        String loginUserEmail = "todo@example.com"; // TODO: 인증 연동 후 교체
-        return exerciseService.createMyExerciseRecords(loginUserEmail, requests);
+    public List<ExerciseRecordResponse> createMyExerciseRecord(
+            @RequestBody @Valid @NotEmpty List<@Valid ExerciseRecordRequest> requests
+    ) {
+        String email = CurrentUser.email();
+        return exerciseService.createMyExerciseRecords(email, requests);
     }
 
     @PutMapping("/{recordId}")
-    public ExerciseRecordResponse updateMyExerciseRecord(@PathVariable("recordId") Long recordId,
-                                                         @RequestBody ExerciseRecordRequest request) {
-        String loginUserEmail = "todo@example.com"; // TODO: 인증 연동 후 교체
-        return exerciseService.updateMyExerciseRecord(loginUserEmail, recordId, request);
+    public ExerciseRecordResponse updateMyExerciseRecord(
+            @PathVariable("recordId") @Positive Long recordId,
+            @RequestBody @Valid ExerciseRecordRequest request
+    ) {
+        String email = CurrentUser.email();
+        return exerciseService.updateMyExerciseRecord(email, recordId, request);
     }
 
     @DeleteMapping("/{recordId}")
-    @ResponseStatus(HttpStatus.OK)
-    public DeleteExerciseRecordResponse deleteMyExerciseRecord(@PathVariable("recordId") Long recordId) {
-        String loginUserEmail = "todo@example.com"; // TODO: 인증 연동 후 교체
-        return exerciseService.deleteMyExerciseRecord(loginUserEmail, recordId);
+    public DeleteExerciseRecordResponse deleteMyExerciseRecord(
+            @PathVariable("recordId") @Positive Long recordId
+    ) {
+        String email = CurrentUser.email();
+        return exerciseService.deleteMyExerciseRecord(email, recordId);
     }
 }

--- a/src/main/groovy/com/yumyumcoach/domain/exercise/dto/ExerciseRecordRequest.java
+++ b/src/main/groovy/com/yumyumcoach/domain/exercise/dto/ExerciseRecordRequest.java
@@ -1,5 +1,7 @@
 package com.yumyumcoach.domain.exercise.dto;
 
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -15,7 +17,11 @@ import java.time.LocalDate;
 @NoArgsConstructor
 @AllArgsConstructor
 public class ExerciseRecordRequest {
+    @NotNull
     private Long exerciseId;
+    @NotNull
     private LocalDate recordDate;
+    @NotNull
+    @Positive
     private Double durationMinutes;
 }

--- a/src/main/groovy/com/yumyumcoach/domain/exercise/mapper/ExerciseRecordMapper.java
+++ b/src/main/groovy/com/yumyumcoach/domain/exercise/mapper/ExerciseRecordMapper.java
@@ -21,4 +21,7 @@ public interface ExerciseRecordMapper {
     void update(ExerciseRecord exerciseRecord);
 
     void delete(@Param("recordId") Long recordId, @Param("email") String email);
+
+    // 추가: recordId로 소유자(email) 조회
+    String findEmailByRecordId(@Param("recordId") Long recordId);
 }

--- a/src/main/groovy/com/yumyumcoach/domain/exercise/service/ExerciseService.java
+++ b/src/main/groovy/com/yumyumcoach/domain/exercise/service/ExerciseService.java
@@ -1,22 +1,20 @@
 package com.yumyumcoach.domain.exercise.service;
 
-import com.yumyumcoach.domain.exercise.dto.DeleteExerciseRecordResponse;
-import com.yumyumcoach.domain.exercise.dto.ExerciseRecordRequest;
-import com.yumyumcoach.domain.exercise.dto.ExerciseRecordResponse;
-import com.yumyumcoach.domain.exercise.dto.ExerciseResponse;
+import com.yumyumcoach.domain.exercise.dto.*;
 import com.yumyumcoach.domain.exercise.entity.Exercise;
 import com.yumyumcoach.domain.exercise.entity.ExerciseRecord;
 import com.yumyumcoach.domain.exercise.entity.ExerciseRecordWithExercise;
 import com.yumyumcoach.domain.exercise.mapper.ExerciseMapper;
 import com.yumyumcoach.domain.exercise.mapper.ExerciseRecordMapper;
 import com.yumyumcoach.domain.exercise.mapper.ProfileMapper;
+import com.yumyumcoach.global.exception.BusinessException;
+import com.yumyumcoach.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -34,46 +32,40 @@ public class ExerciseService {
                 .toList();
     }
 
-    public List<ExerciseRecordResponse> getMyExerciseRecords(String email, LocalDate recordDate) {
+    public List<ExerciseRecordResponse> getMyExerciseRecords(String email, java.time.LocalDate recordDate) {
         return exerciseRecordMapper.findByEmailAndDate(email, recordDate).stream()
                 .map(this::toExerciseRecordResponse)
                 .toList();
     }
 
     public ExerciseRecordResponse getMyExerciseRecordDetail(String email, Long recordId) {
+        checkRecordOwnerOrThrow(email, recordId);
+
         ExerciseRecordWithExercise record = exerciseRecordMapper.findDetailByIdAndEmail(recordId, email);
         if (record == null) {
-            throw new IllegalArgumentException("운동 기록을 찾을 수 없습니다. recordId=" + recordId);
+            throw new BusinessException(ErrorCode.EXERCISE_RECORD_NOT_FOUND);
         }
         return toExerciseRecordResponse(record);
     }
 
     @Transactional
     public List<ExerciseRecordResponse> createMyExerciseRecords(String email, List<ExerciseRecordRequest> requests) {
-        if (requests == null || requests.isEmpty()) {
-            throw new IllegalArgumentException("운동 기록 요청 리스트가 비어 있습니다.");
-        }
-
         return requests.stream()
-                .map(request -> createExerciseRecord(email, request))
+                .map(req -> createExerciseRecord(email, req))
                 .toList();
     }
 
     @Transactional
     public ExerciseRecordResponse updateMyExerciseRecord(String email, Long recordId, ExerciseRecordRequest request) {
-        ExerciseRecordWithExercise existing = exerciseRecordMapper.findDetailByIdAndEmail(recordId, email);
-        if (existing == null) {
-            throw new IllegalArgumentException("운동 기록을 찾을 수 없습니다. recordId=" + recordId);
-        }
+        checkRecordOwnerOrThrow(email, recordId);
 
         double calories = calculateCalories(email, request.getExerciseId(), request.getDurationMinutes());
-        LocalDate recordDate = requireRecordDate(request.getRecordDate());
 
         ExerciseRecord exerciseRecord = ExerciseRecord.builder()
                 .id(recordId)
                 .email(email)
                 .exerciseId(request.getExerciseId())
-                .recordDate(recordDate)
+                .recordDate(request.getRecordDate())
                 .durationMinutes(request.getDurationMinutes())
                 .calories(calories)
                 .build();
@@ -84,16 +76,49 @@ public class ExerciseService {
 
     @Transactional
     public DeleteExerciseRecordResponse deleteMyExerciseRecord(String email, Long recordId) {
-        ExerciseRecordWithExercise existing = exerciseRecordMapper.findDetailByIdAndEmail(recordId, email);
-        if (existing == null) {
-            throw new IllegalArgumentException("운동 기록을 찾을 수 없습니다. recordId=" + recordId);
-        }
+        checkRecordOwnerOrThrow(email, recordId);
+
         exerciseRecordMapper.delete(recordId, email);
+
         return DeleteExerciseRecordResponse.builder()
                 .recordId(recordId)
                 .deleted(true)
                 .deletedAt(LocalDateTime.now())
                 .build();
+    }
+
+    // -------------------------
+    // 비즈니스 예외(403/404)만
+    // -------------------------
+    private void checkRecordOwnerOrThrow(String email, Long recordId) {
+        String ownerEmail = exerciseRecordMapper.findEmailByRecordId(recordId);
+
+        if (ownerEmail == null) {
+            throw new BusinessException(ErrorCode.EXERCISE_RECORD_NOT_FOUND);
+        }
+        if (!ownerEmail.equalsIgnoreCase(email)) {
+            throw new BusinessException(ErrorCode.EXERCISE_RECORD_FORBIDDEN);
+        }
+    }
+
+    private double calculateCalories(String email, Long exerciseId, Double durationMinutes) {
+        Exercise exercise = exerciseMapper.findById(exerciseId);
+        if (exercise == null) {
+            throw new BusinessException(ErrorCode.EXERCISE_NOT_FOUND);
+        }
+
+        Double currentWeight = profileMapper.findCurrentWeightByEmail(email);
+        if (currentWeight == null) {
+            // TODO: 500 에러 대신 다른 에러로 교체하기
+            throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR);
+        }
+
+        double durationHours = durationMinutes / 60.0;
+        double rawCalories = exercise.getMet() * currentWeight * durationHours;
+
+        return BigDecimal.valueOf(rawCalories)
+                .setScale(2, RoundingMode.HALF_UP)
+                .doubleValue();
     }
 
     private ExerciseResponse toExerciseResponse(Exercise exercise) {
@@ -121,39 +146,13 @@ public class ExerciseService {
                 .build();
     }
 
-    private double calculateCalories(String email, Long exerciseId, Double durationMinutes) {
-        Exercise exercise = exerciseMapper.findById(exerciseId);
-        if (exercise == null) {
-            throw new IllegalArgumentException("운동 정보를 찾을 수 없습니다. exerciseId=" + exerciseId);
-        }
-
-        Double currentWeight = profileMapper.findCurrentWeightByEmail(email);
-        if (currentWeight == null) {
-            throw new IllegalArgumentException("현재 사용자 프로필의 몸무게 정보를 찾을 수 없습니다. email=" + email);
-        }
-
-        double durationHours = durationMinutes / 60.0;
-        double rawCalories = exercise.getMet() * currentWeight * durationHours;
-        return BigDecimal.valueOf(rawCalories)
-                .setScale(2, RoundingMode.HALF_UP)
-                .doubleValue();
-    }
-
-    private LocalDate requireRecordDate(LocalDate recordDate) {
-        if (recordDate == null) {
-            throw new IllegalArgumentException("운동 기록 날짜는 필수입니다.");
-        }
-        return recordDate;
-    }
-
     private ExerciseRecordResponse createExerciseRecord(String email, ExerciseRecordRequest request) {
         double calories = calculateCalories(email, request.getExerciseId(), request.getDurationMinutes());
-        LocalDate recordDate = requireRecordDate(request.getRecordDate());
 
         ExerciseRecord exerciseRecord = ExerciseRecord.builder()
                 .email(email)
                 .exerciseId(request.getExerciseId())
-                .recordDate(recordDate)
+                .recordDate(request.getRecordDate())
                 .durationMinutes(request.getDurationMinutes())
                 .calories(calories)
                 .build();
@@ -162,3 +161,4 @@ public class ExerciseService {
         return getMyExerciseRecordDetail(email, exerciseRecord.getId());
     }
 }
+

--- a/src/main/groovy/com/yumyumcoach/global/exception/ErrorCode.java
+++ b/src/main/groovy/com/yumyumcoach/global/exception/ErrorCode.java
@@ -32,7 +32,12 @@ public enum ErrorCode {
     CHALLENGE_JOIN_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "현재는 해당 챌린지에 참여할 수 없습니다."),
     CHALLENGE_JOIN_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 챌린지에 대한 참여 이력을 찾을 수 없습니다."),
     CHALLENGE_LEAVE_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "현재는 해당 챌린지에서 나갈 수 없습니다."),
-    CHALLENGE_ALREADY_LEFT(HttpStatus.CONFLICT, "이미 나간 챌린지입니다.");
+    CHALLENGE_ALREADY_LEFT(HttpStatus.CONFLICT, "이미 나간 챌린지입니다."),
+
+    // ===== EXERCISE =====
+    EXERCISE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 운동을 찾을 수 없습니다."),
+    EXERCISE_RECORD_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 운동 기록을 찾을 수 없습니다."),
+    EXERCISE_RECORD_FORBIDDEN(HttpStatus.FORBIDDEN, "해당 운동 기록에 대한 권한이 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/groovy/com/yumyumcoach/global/exception/GlobalExceptionHandler.java
+++ b/src/main/groovy/com/yumyumcoach/global/exception/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.MalformedJwtException;
 import io.jsonwebtoken.UnsupportedJwtException;
 import io.jsonwebtoken.security.SignatureException;
+import jakarta.validation.ConstraintViolationException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -43,6 +44,13 @@ public class GlobalExceptionHandler {
         return ResponseEntity.badRequest().body(ErrorResponse.from(ErrorCode.INVALID_REQUEST));
     }
 
+    // 메서드 파라미터 검증 실패(@Validated, @Positive 등) -> 400
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<ErrorResponse> handleConstraintViolation(ConstraintViolationException e) {
+        return ResponseEntity.badRequest()
+                .body(ErrorResponse.from(ErrorCode.INVALID_REQUEST));
+    }
+
     // JSON 바디가 깨짐/파싱 실패 -> 400
     @ExceptionHandler(org.springframework.http.converter.HttpMessageNotReadableException.class)
     public ResponseEntity<ErrorResponse> handleNotReadable(Exception e) {
@@ -58,6 +66,7 @@ public class GlobalExceptionHandler {
     // 나머지 -> 500
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponse> handleUnknown(Exception e) {
+        e.printStackTrace();
         return ResponseEntity.status(ErrorCode.INTERNAL_SERVER_ERROR.getHttpStatus())
                 .body(ErrorResponse.from(ErrorCode.INTERNAL_SERVER_ERROR));
     }

--- a/src/main/resources/mapper/exercise/ExerciseRecordMapper.xml
+++ b/src/main/resources/mapper/exercise/ExerciseRecordMapper.xml
@@ -70,4 +70,10 @@
         WHERE id = #{recordId}
           AND email = #{email}
     </delete>
+
+    <select id="findEmailByRecordId" resultType="string">
+        SELECT email
+        FROM exercise_records
+        WHERE id = #{recordId}
+    </select>
 </mapper>


### PR DESCRIPTION
## 🔗 관련 이슈

#41 

## ✨ 작업 내용

### 1) Exercise(운동 기록) API 예외처리/검증 적용

* 운동 기록 API에 검증(@Valid) 및 예외처리(400/401/403/404) 적용
  * 400: 요청 값 오류(날짜 형식/누락, durationMinutes 음수/0 등) → `INVALID_REQUEST`
  * 401: 인증 실패(토큰 없거나 유효하지 않음) → `AUTH_UNAUTHORIZED`
  * 403: 내 기록이 아닌데 접근/수정/삭제 시도 → `EXERCISE_RECORD_FORBIDDEN`
  * 404: 존재하지 않는 recordId / exerciseId → `EXERCISE_RECORD_NOT_FOUND`, `EXERCISE_NOT_FOUND`
* `findEmailByRecordId`로 운동 기록 소유자 확인 후 불일치 시 403 처리
* 댓글 서비스 `requireEmail` 제거(인증은 컨트롤러/시큐리티에서 처리)
* 댓글 삭제 시 `postId`까지 검증하도록 조회 로직 개선 (`findByIdAndPostId`)

## 📌 참고 사항

* 예외 응답 포맷은 기존 `GlobalExceptionHandler/ErrorResponse` 규격을 따릅니다.
