### PR TITLE
fix(#62): CORS(preflight) 허용 및 local 임시 인증 우회 추가

### DIFF
--- a/src/main/groovy/com/yumyumcoach/domain/auth/service/AuthService.java
+++ b/src/main/groovy/com/yumyumcoach/domain/auth/service/AuthService.java
@@ -5,6 +5,7 @@ import com.yumyumcoach.domain.auth.entity.Account;
 import com.yumyumcoach.domain.auth.entity.RefreshToken;
 import com.yumyumcoach.domain.auth.mapper.AccountMapper;
 import com.yumyumcoach.domain.auth.mapper.RefreshTokenMapper;
+import com.yumyumcoach.domain.user.mapper.ProfileMapper;
 import com.yumyumcoach.global.exception.BusinessException;
 import com.yumyumcoach.global.exception.ErrorCode;
 import com.yumyumcoach.global.jwt.JwtTokenProvider;
@@ -22,6 +23,7 @@ import java.util.regex.Pattern;
 public class AuthService {
 
     private final AccountMapper accountMapper;
+    private final ProfileMapper profileMapper;
     private final PasswordEncoder passwordEncoder;
     private final JwtTokenProvider jwtTokenProvider;
     private final RefreshTokenMapper refreshTokenMapper;
@@ -105,6 +107,7 @@ public class AuthService {
         }
 
         createAccount(request);
+        profileMapper.insertEmpty(request.getEmail());
         return new SignUpResponse(request.getEmail(), request.getUsername());
     }
 

--- a/src/main/groovy/com/yumyumcoach/global/config/SecurityConfig.java
+++ b/src/main/groovy/com/yumyumcoach/global/config/SecurityConfig.java
@@ -1,11 +1,15 @@
 package com.yumyumcoach.global.config;
 
+import com.yumyumcoach.global.jwt.DevAuthenticationFilter;
 import com.yumyumcoach.global.jwt.JwtAuthenticationFilter;
 import com.yumyumcoach.global.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -14,7 +18,12 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import org.springframework.web.servlet.HandlerExceptionResolver;
+
+import java.util.List;
 
 @Configuration
 @EnableWebSecurity
@@ -32,21 +41,33 @@ public class SecurityConfig {
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http,
-                                                   JwtAuthenticationFilter jwtAuthenticationFilter) throws Exception {
+                                                   JwtAuthenticationFilter jwtAuthenticationFilter,
+                                                   ObjectProvider<DevAuthenticationFilter> devFilterProvider
+    ) throws Exception {
         http
+                .cors(Customizer.withDefaults())
                 .csrf(AbstractHttpConfigurer::disable)
                 .formLogin(AbstractHttpConfigurer::disable)
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                         .requestMatchers("/api/auth/sign-in",
                                 "/api/auth/check-email",
                                 "/api/auth/check-username",
                                 "/api/auth/sign-up",
                                 "/api/auth/refresh").permitAll()
                         .anyRequest().authenticated()
-                )
-                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+                );
+
+        // ✅ dev일 때만 존재 → 있으면 JWT 필터보다 먼저
+        DevAuthenticationFilter devFilter = devFilterProvider.getIfAvailable();
+        if (devFilter != null) {
+            http.addFilterBefore(devFilter, UsernamePasswordAuthenticationFilter.class);
+            http.addFilterAfter(jwtAuthenticationFilter, DevAuthenticationFilter.class);
+        } else {
+            http.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+        }
 
         return http.build();
     }
@@ -54,5 +75,19 @@ public class SecurityConfig {
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowedOrigins(List.of("http://localhost:5173"));
+        config.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+        config.setAllowedHeaders(List.of("Authorization", "Content-Type", "X-DEV-EMAIL"));
+        config.setExposedHeaders(List.of("Authorization"));
+        config.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+        return source;
     }
 }

--- a/src/main/groovy/com/yumyumcoach/global/jwt/DevAuthenticationFilter.java
+++ b/src/main/groovy/com/yumyumcoach/global/jwt/DevAuthenticationFilter.java
@@ -1,0 +1,44 @@
+package com.yumyumcoach.global.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Collections;
+
+@Profile("dev")
+@Component
+public class DevAuthenticationFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain chain) throws ServletException, IOException {
+
+        // 이미 인증돼 있으면 패스
+        if (SecurityContextHolder.getContext().getAuthentication() != null) {
+            chain.doFilter(request, response);
+            return;
+        }
+
+        // dev 전용 헤더로 인증 주입
+        String devEmail = request.getHeader("X-DEV-EMAIL");
+        if (devEmail != null && !devEmail.isBlank()) {
+            var auth = new UsernamePasswordAuthenticationToken(
+                    devEmail,
+                    null,
+                    Collections.emptyList()
+            );
+            SecurityContextHolder.getContext().setAuthentication(auth);
+        }
+
+        chain.doFilter(request, response);
+    }
+}

--- a/src/main/groovy/com/yumyumcoach/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/groovy/com/yumyumcoach/global/jwt/JwtAuthenticationFilter.java
@@ -11,6 +11,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -33,12 +34,25 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         try {
+            if ("OPTIONS".equalsIgnoreCase(request.getMethod())) {
+                filterChain.doFilter(request, response);
+                return;
+            }
+
             // 인증이 필요 없는 경로면 그냥 통과(로그인, 회원가입 등)
             String uri = request.getRequestURI();
             if(uri.startsWith("/api/auth/sign-in") || uri.startsWith("/api/auth/sign-up") ||
                 uri.startsWith("/api/auth/check-email") || uri.startsWith("/api/auth/check-username") ||
                 uri.startsWith("/api/auth/refresh")) {
                 filterChain.doFilter(request,response);
+                return;
+            }
+
+            // ✅ 이미 인증이 세팅되어 있으면(JWT든 dev든) 그대로 통과
+            Authentication existing = SecurityContextHolder.getContext().getAuthentication();
+            if (existing != null && existing.isAuthenticated()
+                    && !"anonymousUser".equals(String.valueOf(existing.getPrincipal()))) {
+                filterChain.doFilter(request, response);
                 return;
             }
 


### PR DESCRIPTION
## 🔗 관련 이슈

> #62 

## ✨ 작업 내용

- Spring Security CORS 활성화 및 CORS 정책 추가 (5173 → 8080 허용)
- OPTIONS preflight 요청 permitAll 처리
- 허용 헤더에 Authorization / Content-Type / X-DEV-EMAIL 포함
- local 프로필에서만 동작하는 DevAuthenticationFilter 추가(개발용 임시 인증 우회)

## 📌 참고 사항

> 프론트에서 게시글 작성 POST 요청 정상 처리됨을 확인
