### PR TITLE
fix(#64): 커뮤니티 게시글/댓글 작성자 정보 null 응답 수정

### DIFF
--- a/src/main/groovy/com/yumyumcoach/domain/community/entity/Post.java
+++ b/src/main/groovy/com/yumyumcoach/domain/community/entity/Post.java
@@ -18,7 +18,10 @@ public class Post {
 //    private String category;
     private LocalDateTime createdAt;
     private int likes;
+    private Long authorId;
     private String authorEmail;
+    private String authorUsername;
+    private String authorProfileImageUrl;
 
     // 나중에 category 추가시 주석 풀기
 //    public void update(String title, String content, String category) {

--- a/src/main/groovy/com/yumyumcoach/domain/community/entity/PostComment.java
+++ b/src/main/groovy/com/yumyumcoach/domain/community/entity/PostComment.java
@@ -14,7 +14,10 @@ import java.time.LocalDateTime;
 public class PostComment {
     private Long id;            // PK
     private Long postId;        // FK(posts.id)
+    private Long authorId;
     private String authorEmail; // FK(accounts.email)
+    private String authorUsername;
+    private String authorProfileImageUrl;
     private String content;
     private LocalDateTime createdAt;
 

--- a/src/main/groovy/com/yumyumcoach/domain/community/mapper/PostCommentMapper.java
+++ b/src/main/groovy/com/yumyumcoach/domain/community/mapper/PostCommentMapper.java
@@ -23,5 +23,5 @@ public interface PostCommentMapper {
 
     void deleteByPostId(@Param("postId") Long postId);
 
-    PostComment findByIdAndPostId(Long commentId, Long postId);
+    PostComment findByIdAndPostId(@Param("commentId") Long commentId, @Param("postId") Long postId);
 }

--- a/src/main/groovy/com/yumyumcoach/domain/community/service/CommentService.java
+++ b/src/main/groovy/com/yumyumcoach/domain/community/service/CommentService.java
@@ -8,6 +8,7 @@ import com.yumyumcoach.domain.community.entity.Post;
 import com.yumyumcoach.domain.community.entity.PostComment;
 import com.yumyumcoach.domain.community.mapper.PostCommentMapper;
 import com.yumyumcoach.domain.community.mapper.PostMapper;
+import com.yumyumcoach.global.common.CdnUrlResolver;
 import com.yumyumcoach.global.exception.BusinessException;
 import com.yumyumcoach.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -28,6 +29,7 @@ import java.util.List;
 public class CommentService {
     private final PostMapper postMapper;
     private final PostCommentMapper postCommentMapper;
+    private final CdnUrlResolver cdnUrlResolver;
 
     /**
      * 특정 게시글의 댓글 목록 조회
@@ -49,9 +51,11 @@ public class CommentService {
                         .commentId(comment.getId())
                         .postId(comment.getPostId())
                         // User 도메인 연동 전 : 일단 author 관련은 null로 세팅
-                        .authorId(null)
-                        .authorUsername(null)
-                        .authorProfileImageUrl(null)
+                        .authorId(comment.getAuthorId())
+                        .authorUsername(comment.getAuthorUsername())
+                        .authorProfileImageUrl(
+                                comment.getAuthorProfileImageUrl() == null ? null : cdnUrlResolver.resolve(comment.getAuthorProfileImageUrl())
+                        )
                         .content(comment.getContent())
                         .createdAt(comment.getCreatedAt())
                         .build()
@@ -89,14 +93,18 @@ public class CommentService {
         // 3) DB 저장 (id 자동 증가)
         postCommentMapper.insert(comment); // useGeneratedKeys=true 로 인해 comment.id 세팅됨
 
+        PostComment saved = postCommentMapper.findByIdAndPostId(comment.getId(), postId);
+
         return CommentResponse.builder()
-                .commentId(comment.getId())
+                .commentId(saved.getId())
                 .postId(postId)
-                .authorId(null)   // TODO: User 도메인 연동 후 세팅
-                .authorUsername(null)
-                .authorProfileImageUrl(null)
-                .content(comment.getContent())
-                .createdAt(comment.getCreatedAt())
+                .authorId(saved.getAuthorId())
+                .authorUsername(saved.getAuthorUsername())
+                .authorProfileImageUrl(
+                        saved.getAuthorProfileImageUrl() == null ? null : cdnUrlResolver.resolve(saved.getAuthorProfileImageUrl())
+                )
+                .content(saved.getContent())
+                .createdAt(saved.getCreatedAt())
                 .build();
     }
 
@@ -124,14 +132,18 @@ public class CommentService {
                 .content(request.getContent())
                 .build());
 
+        PostComment updated = postCommentMapper.findByIdAndPostId(commentId, postId);
+
         return CommentResponse.builder()
                 .commentId(commentId)
                 .postId(postId)
-                .authorId(null)
-                .authorUsername(null)
-                .authorProfileImageUrl(null)
-                .content(request.getContent())
-                .createdAt(existing.getCreatedAt())
+                .authorId(updated.getAuthorId())
+                .authorUsername(updated.getAuthorUsername())
+                .authorProfileImageUrl(
+                        updated.getAuthorProfileImageUrl() == null ? null : cdnUrlResolver.resolve(updated.getAuthorProfileImageUrl())
+                )
+                .content(updated.getContent())
+                .createdAt(updated.getCreatedAt())
                 .build();
     }
 

--- a/src/main/groovy/com/yumyumcoach/domain/community/service/PostService.java
+++ b/src/main/groovy/com/yumyumcoach/domain/community/service/PostService.java
@@ -44,7 +44,6 @@ public class PostService {
      * - GET /api/posts
      */
     public GetPostsResponse getPosts(GetPostsRequest request, String loginUserEmail) {
-        // TODO:
         // 1) request.getPage(), request.getSize()를 사용해 페이징 조회
         int page = request.getPage();
         int size = request.getSize();
@@ -86,10 +85,11 @@ public class PostService {
 
                     return PostResponse.builder()
                             .postId(postId)
-                            // User 도메인 연동 전 : 일단 author 관련은 null로 세팅
-                            .authorId(null)
-                            .authorUsername(null)
-                            .authorProfileImageUrl(null)
+                            .authorId(post.getAuthorId())
+                            .authorUsername(post.getAuthorUsername())
+                            .authorProfileImageUrl(
+                                    post.getAuthorProfileImageUrl() == null ? null : cdnUrlResolver.resolve(post.getAuthorProfileImageUrl())
+                            )
                             .title(post.getTitle())
                             .content(post.getContent())
                             .images(imageUrls)
@@ -136,13 +136,16 @@ public class PostService {
         int likeCount = post.getLikes();
 
         // 5) 현재 유저가 좋아요 눌렀는지 여부
-        boolean isLikedByMe = postLikeMapper.existsByPostIdAndAuthorEmail(postId, loginUserEmail);
+        boolean isLikedByMe = loginUserEmail != null
+                && postLikeMapper.existsByPostIdAndAuthorEmail(postId, loginUserEmail);
 
         return PostResponse.builder()
                 .postId(post.getId())
-                .authorId(null)                 // TODO: User 도메인 연동 후 세팅
-                .authorUsername(null)
-                .authorProfileImageUrl(null)
+                .authorId(post.getAuthorId())
+                .authorUsername(post.getAuthorUsername())
+                .authorProfileImageUrl(
+                        post.getAuthorProfileImageUrl() == null ? null : cdnUrlResolver.resolve(post.getAuthorProfileImageUrl())
+                )
                 .title(post.getTitle())
                 .content(post.getContent())
                 .images(imageUrls)
@@ -185,25 +188,7 @@ public class PostService {
             postImageMapper.insert(postImage);
         }
 
-        // 4) 응답용은 objectKey -> CloudFront URL로 변환
-        List<String> imageCdnUrls = images.stream()
-                .map(cdnUrlResolver::resolve)
-                .toList();
-
-        return PostResponse.builder()
-                .postId(postId)
-                .authorId(null)               // TODO: User 도메인 연동 후 세팅
-                .authorUsername(null)
-                .authorProfileImageUrl(null)
-                .title(post.getTitle())
-                .content(post.getContent())
-                .images(imageCdnUrls)
-                .likeCount(0)
-                .commentCount(0)
-                .isLikedByMe(false)
-                .createdAt(post.getCreatedAt())
-                .updatedAt(null)
-                .build();
+        return getPost(postId, loginUserEmail);
     }
 
     /**
@@ -245,30 +230,7 @@ public class PostService {
             postImageMapper.insert(postImage);
         }
 
-        // 4) 댓글 수, 좋아요 수, isLikedByMe 다시 조회
-        long commentCount = postCommentMapper.countByPostId(postId);
-        int likeCount = existing.getLikes();
-        boolean isLikedByMe = postLikeMapper.existsByPostIdAndAuthorEmail(postId, loginUserEmail);
-
-        // 5) 응답용은 objectKey -> CloudFront URL로 변환
-        List<String> imageCdnUrls = images.stream()
-                .map(cdnUrlResolver::resolve)
-                .toList();
-
-        return PostResponse.builder()
-                .postId(postId)
-                .authorId(null)
-                .authorUsername(null)
-                .authorProfileImageUrl(null)
-                .title(request.getTitle())
-                .content(request.getContent())
-                .images(imageCdnUrls)
-                .likeCount(likeCount)
-                .commentCount((int) commentCount)
-                .isLikedByMe(isLikedByMe)
-                .createdAt(existing.getCreatedAt())
-                .updatedAt(null)
-                .build();
+        return getPost(postId, loginUserEmail);
     }
 
     /**

--- a/src/main/groovy/com/yumyumcoach/domain/image/dto/PresignRequest.java
+++ b/src/main/groovy/com/yumyumcoach/domain/image/dto/PresignRequest.java
@@ -6,7 +6,7 @@ import lombok.Setter;
 @Getter
 @Setter
 public class PresignRequest {
-    private ImagePurpose purpose;   // PROFILE/POST/MEAL
+    private ImagePurpose purpose;   // PROFILE/POST/DIET/CHALLENGE
     private String fileName;        // test.png (확장자 추출용)
     private String contentType;     // image/png
 }

--- a/src/main/resources/mapper/community/PostCommentMapper.xml
+++ b/src/main/resources/mapper/community/PostCommentMapper.xml
@@ -9,16 +9,27 @@
         <id column="id" property="id"/>
         <result column="post_id" property="postId"/>
         <result column="author_email" property="authorEmail"/>
+        <result column="author_id" property="authorId"/>
         <result column="content" property="content"/>
         <result column="created_at" property="createdAt"/>
     </resultMap>
 
     <!-- 특정 게시글의 댓글 목록 -->
     <select id="findByPostId" parameterType="long" resultMap="PostCommentResultMap">
-        SELECT id, post_id, author_email, content, created_at
-        FROM post_comments
-        WHERE post_id = #{postId}
-        ORDER BY created_at ASC
+        SELECT
+        c.id,
+        c.post_id,
+        c.author_email,
+        a.id AS author_id,
+        a.username AS author_username,
+        pr.profile_image_url AS author_profile_image_url,
+        c.content,
+        c.created_at
+        FROM post_comments c
+        JOIN accounts a ON a.email = c.author_email
+        LEFT JOIN profiles pr ON pr.email = c.author_email
+        WHERE c.post_id = #{postId}
+        ORDER BY c.created_at ASC
     </select>
 
     <!-- 댓글 개수 -->
@@ -30,9 +41,19 @@
 
     <!-- 댓글 단건 조회 -->
     <select id="findById" parameterType="long" resultMap="PostCommentResultMap">
-        SELECT id, post_id, author_email, content, created_at
-        FROM post_comments
-        WHERE id = #{commentId}
+        SELECT
+        c.id,
+        c.post_id,
+        c.author_email,
+        a.id AS author_id,
+        a.username AS author_username,
+        pr.profile_image_url AS author_profile_image_url,
+        c.content,
+        c.created_at
+        FROM post_comments c
+        JOIN accounts a ON a.email = c.author_email
+        LEFT JOIN profiles pr ON pr.email = c.author_email
+        WHERE c.id = #{commentId}
     </select>
 
     <!-- 댓글 INSERT -->
@@ -68,11 +89,21 @@
     </delete>
 
     <!-- 특정 게시글에 해당 하는 댓글 단건 조회 -->
-    <select id="findByIdAndPostId" resultType="com.yumyumcoach.domain.community.entity.PostComment">
-        SELECT *
-        FROM post_comments
-        WHERE id = #{commentId}
-          AND post_id = #{postId}
+    <select id="findByIdAndPostId" resultMap="PostCommentResultMap">
+        SELECT
+        c.id,
+        c.post_id,
+        c.author_email,
+        a.id AS author_id,
+        a.username AS author_username,
+        pr.profile_image_url AS author_profile_image_url,
+        c.content,
+        c.created_at
+        FROM post_comments c
+        JOIN accounts a ON a.email = c.author_email
+        LEFT JOIN profiles pr ON pr.email = c.author_email
+        WHERE c.id = #{commentId}
+        AND c.post_id = #{postId}
     </select>
 
 </mapper>

--- a/src/main/resources/mapper/community/PostMapper.xml
+++ b/src/main/resources/mapper/community/PostMapper.xml
@@ -7,6 +7,9 @@
     <resultMap id="PostResultMap" type="com.yumyumcoach.domain.community.entity.Post">
         <id column="id" property="id"/>
         <result column="author_email" property="authorEmail"/>
+        <result column="author_id" property="authorId"/>
+        <result column="author_username" property="authorUsername"/>
+        <result column="author_profile_image_url" property="authorProfileImageUrl"/>
         <result column="title" property="title"/>
         <result column="content" property="content"/>
         <result column="created_at" property="createdAt"/>
@@ -15,18 +18,39 @@
 
     <!-- 단건 조회 -->
     <select id="findById" parameterType="long" resultMap="PostResultMap">
-        SELECT id, author_email, title, content, created_at, likes
-        FROM posts
-        WHERE id = #{postId}
+        SELECT
+            p.id,
+            p.author_email,
+            a.id AS author_id,
+            a.username AS author_username,
+            pr.profile_image_url AS author_profile_image_url,
+            p.title,
+            p.content,
+            p.created_at,
+            p.likes
+        FROM posts p
+                 JOIN accounts a ON a.email = p.author_email
+                 LEFT JOIN profiles pr ON pr.email = p.author_email
+        WHERE p.id = #{postId}
     </select>
 
     <!-- 목록 조회 (페이징) -->
     <select id="findPosts" parameterType="map" resultMap="PostResultMap">
-        SELECT id, author_email, title, content, created_at, likes
-        FROM posts
-        <!-- [TODO] keyword, sort 나중에 조건 추가 -->
-        ORDER BY created_at DESC
-        LIMIT #{size} OFFSET #{offset}
+        SELECT
+            p.id,
+            p.author_email,
+            a.id AS author_id,
+            a.username AS author_username,
+            pr.profile_image_url AS author_profile_image_url,
+            p.title,
+            p.content,
+            p.created_at,
+            p.likes
+        FROM posts p
+                 JOIN accounts a ON a.email = p.author_email
+                 LEFT JOIN profiles pr ON pr.email = p.author_email
+        ORDER BY p.created_at DESC
+            LIMIT #{size} OFFSET #{offset}
     </select>
 
     <!-- 전체 게시글 개수 -->


### PR DESCRIPTION
## 🔗 관련 이슈

* closes #64 

## ✨ 작업 내용

* 게시글/댓글 조회 시 작성자 정보(`authorId`, `authorUsername`, `authorProfileImageUrl`)가 `null`로 내려가던 문제 수정
* `posts.author_email` 기준으로 `accounts`, `profiles` 조인하여 작성자 정보 포함하도록 조회 쿼리 개선
* 프론트에서 `null` 접근으로 발생하던 렌더링 오류 방지 (작성자 정보 정상 응답)

## 📌 참고 사항


