### PR TITLE
refactor(#66): 타이틀(뱃지) 도메인 분리 및 마이페이지 타이틀 API 추가

### DIFF
--- a/db/20251221_refactoring_title.sql
+++ b/db/20251221_refactoring_title.sql
@@ -1,0 +1,9 @@
+ALTER TABLE titles
+    ADD COLUMN icon_emoji VARCHAR(16) DEFAULT NULL AFTER id;
+
+ALTER TABLE challenge_rules
+    ADD COLUMN reward_title_id BIGINT UNSIGNED NOT NULL AFTER difficulty_code;
+
+ALTER TABLE challenge_rules
+    ADD CONSTRAINT fk_challenge_rules_reward_title
+        FOREIGN KEY (reward_title_id) REFERENCES titles(id);

--- a/db/init.sql
+++ b/db/init.sql
@@ -33,6 +33,7 @@ CREATE TABLE IF NOT EXISTS titles (
 id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
 name VARCHAR(255) NOT NULL,
 description VARCHAR(255) DEFAULT NULL,
+icon_emoji VARCHAR(32) DEFAULT NULL,
 PRIMARY KEY (id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
@@ -222,11 +223,14 @@ challenge_id BIGINT UNSIGNED NOT NULL,
 difficulty_code VARCHAR(255) NOT NULL,
 required_success_days INT NOT NULL,
 daily_target_value DOUBLE DEFAULT NULL,
+reward_title_id BIGINT UNSIGNED DEFAULT NULL,
 PRIMARY KEY (challenge_id, difficulty_code),
 CONSTRAINT fk_challenge_rules_challenge
 FOREIGN KEY (challenge_id) REFERENCES challenges(id),
 CONSTRAINT fk_challenge_rules_difficulty
 FOREIGN KEY (difficulty_code) REFERENCES challenge_difficulties(code)
+CONSTRAINT fk_challenge_rules_reward_title
+FOREIGN KEY (reward_title_id) REFERENCES titles(id);
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 -- 17) challenge_participants (최종: difficulty/required/daily + success_days)

--- a/src/main/groovy/com/yumyumcoach/domain/challenge/dto/ChallengeResponse.java
+++ b/src/main/groovy/com/yumyumcoach/domain/challenge/dto/ChallengeResponse.java
@@ -5,6 +5,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 /**
  * 공용 챌린지 응답 DTO.
  * - 목록 카드
@@ -123,6 +125,11 @@ public class ChallengeResponse {
      * 참여하지 않은 경우 null
      */
     private Double progressPercentage;
+
+    /**
+     * 난이도별 칭호 (초급/중급/고급)
+     */
+    private List<RewardTitleResponse> rewardTitles;
 }
 
 

--- a/src/main/groovy/com/yumyumcoach/domain/challenge/dto/RewardTitleResponse.java
+++ b/src/main/groovy/com/yumyumcoach/domain/challenge/dto/RewardTitleResponse.java
@@ -1,0 +1,23 @@
+package com.yumyumcoach.domain.challenge.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RewardTitleResponse {
+    private String difficultyCode;        // BEGINNER/INTERMEDIATE/ADVANCED
+    private String difficultyName;        // 초급/중급/고급 (join)
+    private Integer requiredSuccessDays;  // 목표 일수
+    private Double dailyTargetValue;      // 단백질 g 계수 등 (없으면 null)
+
+    private Long titleId;
+    private String iconEmoji;
+    private String titleName;
+    private String titleDescription;
+}
+

--- a/src/main/groovy/com/yumyumcoach/domain/challenge/entity/ChallengeRule.java
+++ b/src/main/groovy/com/yumyumcoach/domain/challenge/entity/ChallengeRule.java
@@ -1,5 +1,6 @@
 package com.yumyumcoach.domain.challenge.entity;
 
+import com.yumyumcoach.domain.title.entity.Title;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -33,4 +34,9 @@ public class ChallengeRule {
      * - EXERCISE_MINUTES_PER_DAY: 분
      */
     private Double dailyTargetValue;
+
+    /**
+     * 난이도별 보상 타이틀 id
+     */
+    private Long rewardTitleId;
 }

--- a/src/main/groovy/com/yumyumcoach/domain/challenge/mapper/ChallengeRuleMapper.java
+++ b/src/main/groovy/com/yumyumcoach/domain/challenge/mapper/ChallengeRuleMapper.java
@@ -1,8 +1,11 @@
 package com.yumyumcoach.domain.challenge.mapper;
 
+import com.yumyumcoach.domain.challenge.dto.RewardTitleResponse;
 import com.yumyumcoach.domain.challenge.entity.ChallengeRule;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
 
 @Mapper
 public interface ChallengeRuleMapper {
@@ -17,5 +20,10 @@ public interface ChallengeRuleMapper {
             @Param("challengeId") Long challengeId,
             @Param("difficultyCode") String difficultyCode
     );
+
+    /**
+     * 챌린지 1개에 대한 난이도별 보상 3개를 조회한다.
+     */
+    List<RewardTitleResponse> findRewardTitlesByChallengeId(@Param("challengeId") Long challengeId);
 }
 

--- a/src/main/groovy/com/yumyumcoach/domain/challenge/service/ChallengeService.java
+++ b/src/main/groovy/com/yumyumcoach/domain/challenge/service/ChallengeService.java
@@ -5,8 +5,10 @@ import com.yumyumcoach.domain.challenge.entity.Challenge;
 import com.yumyumcoach.domain.challenge.entity.ChallengeParticipant;
 import com.yumyumcoach.domain.challenge.mapper.ChallengeMapper;
 import com.yumyumcoach.domain.challenge.mapper.ChallengeParticipantMapper;
+import com.yumyumcoach.domain.challenge.mapper.ChallengeRuleMapper;
 import com.yumyumcoach.domain.challenge.model.DifficultyCode;
 import com.yumyumcoach.domain.challenge.model.GoalType;
+import com.yumyumcoach.global.common.CdnUrlResolver;
 import com.yumyumcoach.global.exception.BusinessException;
 import com.yumyumcoach.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -29,6 +31,8 @@ public class ChallengeService {
     private final ChallengeMapper challengeMapper;
     private final ChallengeParticipantMapper challengeParticipantMapper;
     private final ChallengeRuleResolver challengeRuleResolver;
+    private final ChallengeRuleMapper challengeRuleMapper;
+    private final CdnUrlResolver cdnUrlResolver;
 
     /**
      * 특정 월 기준 챌린지 목록을 조회한다.
@@ -182,6 +186,9 @@ public class ChallengeService {
 
         int participantsCount = challengeParticipantMapper.countByChallengeId(challenge.getId());
 
+        List<RewardTitleResponse> rewardTitles =
+                challengeRuleMapper.findRewardTitlesByChallengeId(challenge.getId());
+
         Integer successDays = null;
         Double progressPercentage = null;
         String selectedDifficulty = null;
@@ -204,7 +211,7 @@ public class ChallengeService {
                 .shortDescription(challenge.getShortDescription())
                 .goalSummary(challenge.getGoalSummary())
                 .ruleDescription(null) // 목록에서는 유의 사항은 내려주지 않음
-                .imageUrl(challenge.getImageUrl())
+                .imageUrl(cdnUrlResolver.resolve(challenge.getImageUrl()))
                 .type(challenge.getChallengeType())
                 .goalType(challenge.getGoalType())
                 .startDate(challenge.getStartDate().toString())
@@ -216,6 +223,7 @@ public class ChallengeService {
                 .dailyTargetValue(dailyTargetValue)
                 .successDays(successDays)
                 .progressPercentage(progressPercentage)
+                .rewardTitles(rewardTitles)
                 .build();
     }
 
@@ -249,7 +257,7 @@ public class ChallengeService {
                 .shortDescription(challenge.getShortDescription())
                 .goalSummary(challenge.getGoalSummary())
                 .ruleDescription(challenge.getRuleDescription())
-                .imageUrl(challenge.getImageUrl())
+                .imageUrl(cdnUrlResolver.resolve(challenge.getImageUrl()))
                 .type(challenge.getChallengeType())
                 .goalType(challenge.getGoalType())
                 .startDate(challenge.getStartDate().toString())

--- a/src/main/groovy/com/yumyumcoach/domain/title/controller/TitleController.java
+++ b/src/main/groovy/com/yumyumcoach/domain/title/controller/TitleController.java
@@ -1,0 +1,32 @@
+package com.yumyumcoach.domain.title.controller;
+
+import com.yumyumcoach.domain.title.dto.*;
+import com.yumyumcoach.domain.title.service.TitleService;
+import com.yumyumcoach.global.common.CurrentUser;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/users/me")
+public class TitleController {
+
+    private final TitleService titleService;
+
+    @GetMapping("/title")
+    public MyTitleResponse getMyCurrentTitle() {
+        return titleService.getMyCurrentTitle(CurrentUser.email());
+    }
+
+    @PutMapping("/title")
+    public MyTitleResponse updateMyCurrentTitle(@RequestBody UpdateMyTitleRequest request) {
+        return titleService.updateMyCurrentTitle(CurrentUser.email(), request);
+    }
+
+    @GetMapping("/titles")
+    public List<MyTitleItemResponse> getMyTitles() {
+        return titleService.getMyTitles(CurrentUser.email());
+    }
+}

--- a/src/main/groovy/com/yumyumcoach/domain/title/dto/MyTitleItemResponse.java
+++ b/src/main/groovy/com/yumyumcoach/domain/title/dto/MyTitleItemResponse.java
@@ -1,0 +1,19 @@
+package com.yumyumcoach.domain.title.dto;
+
+import lombok.*;
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MyTitleItemResponse {
+    private Long titleId;
+    private String iconEmoji;
+    private String name;
+    private String description;
+
+    private String difficultyName;      // 초급/중급/고급 (nullable)
+    private LocalDateTime obtainedAt;
+    private Long sourceChallengeId;
+}

--- a/src/main/groovy/com/yumyumcoach/domain/title/dto/MyTitleResponse.java
+++ b/src/main/groovy/com/yumyumcoach/domain/title/dto/MyTitleResponse.java
@@ -1,4 +1,4 @@
-package com.yumyumcoach.domain.user.dto;
+package com.yumyumcoach.domain.title.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -17,5 +17,6 @@ public class MyTitleResponse {
 
     private Long currentTitleId;     // profiles.display_title_id
     private String currentTitleName; // titles.name
+    private String currentTitleEmoji;
 }
 

--- a/src/main/groovy/com/yumyumcoach/domain/title/dto/UpdateMyTitleRequest.java
+++ b/src/main/groovy/com/yumyumcoach/domain/title/dto/UpdateMyTitleRequest.java
@@ -1,0 +1,10 @@
+package com.yumyumcoach.domain.title.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class UpdateMyTitleRequest {
+    private Long titleId; // null 허용하면 “대표 타이틀 해제”도 가능
+}

--- a/src/main/groovy/com/yumyumcoach/domain/title/entity/AccountTitle.java
+++ b/src/main/groovy/com/yumyumcoach/domain/title/entity/AccountTitle.java
@@ -1,4 +1,4 @@
-package com.yumyumcoach.domain.user.entity;
+package com.yumyumcoach.domain.title.entity;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src/main/groovy/com/yumyumcoach/domain/title/entity/Title.java
+++ b/src/main/groovy/com/yumyumcoach/domain/title/entity/Title.java
@@ -1,4 +1,4 @@
-package com.yumyumcoach.domain.user.entity;
+package com.yumyumcoach.domain.title.entity;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -28,4 +28,9 @@ public class Title {
      * 타이틀 설명
      */
     private String description;
+
+    /**
+     * 타이틀 이모지
+     */
+    private String iconEmoji;
 }

--- a/src/main/groovy/com/yumyumcoach/domain/title/mapper/TitleMapper.java
+++ b/src/main/groovy/com/yumyumcoach/domain/title/mapper/TitleMapper.java
@@ -1,6 +1,7 @@
-package com.yumyumcoach.domain.user.mapper;
+package com.yumyumcoach.domain.title.mapper;
 
-import com.yumyumcoach.domain.user.dto.MyTitleResponse;
+import com.yumyumcoach.domain.title.dto.MyTitleItemResponse;
+import com.yumyumcoach.domain.title.dto.MyTitleResponse;
 import com.yumyumcoach.domain.user.dto.MyPageResponse;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
@@ -8,7 +9,7 @@ import org.apache.ibatis.annotations.Param;
 import java.util.List;
 
 @Mapper
-public interface UserTitleMapper {
+public interface TitleMapper {
 
     /**
      * 내가 보유한 타이틀인지 여부
@@ -27,6 +28,6 @@ public interface UserTitleMapper {
      * 내가 보유한 타이틀 목록 조회
      * - account_titles + titles 조인
      */
-    List<MyPageResponse.TitleItem> findMyTitles(@Param("email") String email);
+    List<MyTitleItemResponse> findMyTitles(@Param("email") String email);
 }
 

--- a/src/main/groovy/com/yumyumcoach/domain/title/service/TitleService.java
+++ b/src/main/groovy/com/yumyumcoach/domain/title/service/TitleService.java
@@ -1,0 +1,41 @@
+package com.yumyumcoach.domain.title.service;
+
+import com.yumyumcoach.domain.title.dto.*;
+import com.yumyumcoach.domain.title.mapper.TitleMapper;
+import com.yumyumcoach.domain.user.mapper.ProfileMapper;
+import com.yumyumcoach.global.exception.BusinessException;
+import com.yumyumcoach.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class TitleService {
+
+    private final TitleMapper titleMapper;
+    private final ProfileMapper profileMapper;
+
+    public MyTitleResponse getMyCurrentTitle(String email) {
+        return titleMapper.findCurrentTitle(email);
+    }
+
+    public List<MyTitleItemResponse> getMyTitles(String email) {
+        return titleMapper.findMyTitles(email);
+    }
+
+    @Transactional
+    public MyTitleResponse updateMyCurrentTitle(String email, UpdateMyTitleRequest request) {
+        Long titleId = request.getTitleId();
+
+        if (titleId != null && !titleMapper.ownsTitle(email, titleId)) {
+            throw new BusinessException(ErrorCode.TITLE_FORBIDDEN);
+        }
+
+        profileMapper.updateDisplayTitle(email, titleId);
+        return titleMapper.findCurrentTitle(email);
+    }
+}

--- a/src/main/groovy/com/yumyumcoach/domain/user/controller/UserController.java
+++ b/src/main/groovy/com/yumyumcoach/domain/user/controller/UserController.java
@@ -1,13 +1,12 @@
 package com.yumyumcoach.domain.user.controller;
 
 import com.yumyumcoach.domain.user.dto.MyPageResponse;
-import com.yumyumcoach.domain.user.dto.MyTitleResponse;
+import com.yumyumcoach.domain.title.dto.MyTitleResponse;
 import com.yumyumcoach.domain.user.dto.UpdateMyBasicInfoRequest;
 import com.yumyumcoach.domain.user.dto.UpdateMyHealthInfoRequest;
 import com.yumyumcoach.domain.user.service.UserService;
 import com.yumyumcoach.global.common.CurrentUser;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
 @RestController

--- a/src/main/groovy/com/yumyumcoach/domain/user/service/UserService.java
+++ b/src/main/groovy/com/yumyumcoach/domain/user/service/UserService.java
@@ -2,14 +2,15 @@ package com.yumyumcoach.domain.user.service;
 
 import com.yumyumcoach.domain.auth.entity.Account;
 import com.yumyumcoach.domain.auth.mapper.AccountMapper;
-import com.yumyumcoach.domain.user.dto.MyTitleResponse;
+import com.yumyumcoach.domain.title.dto.MyTitleItemResponse;
+import com.yumyumcoach.domain.title.dto.MyTitleResponse;
 import com.yumyumcoach.domain.user.dto.MyPageResponse;
 import com.yumyumcoach.domain.user.dto.UpdateMyBasicInfoRequest;
 import com.yumyumcoach.domain.user.dto.UpdateMyHealthInfoRequest;
 import com.yumyumcoach.domain.user.entity.Profile;
 import com.yumyumcoach.domain.user.mapper.FollowMapper;
 import com.yumyumcoach.domain.user.mapper.ProfileMapper;
-import com.yumyumcoach.domain.user.mapper.UserTitleMapper;
+import com.yumyumcoach.domain.title.mapper.TitleMapper;
 import com.yumyumcoach.global.common.CdnUrlResolver;
 import com.yumyumcoach.global.exception.BusinessException;
 import com.yumyumcoach.global.exception.ErrorCode;
@@ -26,7 +27,7 @@ public class UserService {
     private final AccountMapper accountMapper;
     private final ProfileMapper profileMapper;
     private final FollowMapper followMapper;
-    private final UserTitleMapper userTitleMapper;
+    private final TitleMapper titleMapper;
     private final CdnUrlResolver cdnUrlResolver;
 
     public MyPageResponse getMyPage(String email) {
@@ -45,8 +46,16 @@ public class UserService {
         long followers = followMapper.countFollowers(email);
         long followings = followMapper.countFollowings(email);
 
-        MyTitleResponse current = userTitleMapper.findCurrentTitle(email);
-        List<MyPageResponse.TitleItem> myTitles = userTitleMapper.findMyTitles(email);
+        MyTitleResponse current = titleMapper.findCurrentTitle(email);
+        List<MyTitleItemResponse> myTitleDtos = titleMapper.findMyTitles(email);
+
+        List<MyPageResponse.TitleItem> myTitles = myTitleDtos.stream()
+                .map(t -> MyPageResponse.TitleItem.builder()
+                        .titleId(t.getTitleId())
+                        .name(t.getName())
+                        .description(t.getDescription())
+                        .build())
+                .toList();
 
         return MyPageResponse.builder()
                 .basic(MyPageResponse.Basic.builder()
@@ -161,7 +170,7 @@ public class UserService {
     @Transactional
     public MyTitleResponse selectMyTitle(String email, Long titleId) {
 
-        if (!userTitleMapper.ownsTitle(email, titleId)) {
+        if (!titleMapper.ownsTitle(email, titleId)) {
             throw new BusinessException(ErrorCode.USER_TITLE_NOT_FOUND);
         }
 
@@ -170,6 +179,6 @@ public class UserService {
             throw new BusinessException(ErrorCode.PROFILE_NOT_FOUND);
         }
 
-        return userTitleMapper.findCurrentTitle(email);
+        return titleMapper.findCurrentTitle(email);
     }
 }

--- a/src/main/groovy/com/yumyumcoach/global/exception/ErrorCode.java
+++ b/src/main/groovy/com/yumyumcoach/global/exception/ErrorCode.java
@@ -50,6 +50,8 @@ public enum ErrorCode {
     CHALLENGE_LEAVE_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "현재는 해당 챌린지에서 나갈 수 없습니다."),
     CHALLENGE_ALREADY_LEFT(HttpStatus.CONFLICT, "이미 나간 챌린지입니다."),
 
+    // ===== TITLE =====
+    TITLE_FORBIDDEN(HttpStatus.FORBIDDEN, "해당 뱃지에 대한 권한이 없습니다."),
     // ===== DIET =====
     FOOD_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 음식을 찾을 수 없습니다."),
     DIET_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 식단을 찾을 수 없습니다."),

--- a/src/main/resources/mapper/challenge/ChallengeRuleMapper.xml
+++ b/src/main/resources/mapper/challenge/ChallengeRuleMapper.xml
@@ -11,6 +11,7 @@
         <id     property="difficultyCode"     column="difficulty_code"/>
         <result property="requiredSuccessDays" column="required_success_days"/>
         <result property="dailyTargetValue"   column="daily_target_value"/>
+        <result property="rewardTitleId"      column="reward_title_id"/>
     </resultMap>
 
     <select id="findByChallengeIdAndDifficulty"
@@ -23,6 +24,25 @@
         FROM challenge_rules
         WHERE challenge_id = #{challengeId}
           AND difficulty_code = #{difficultyCode}
+    </select>
+
+    <select id="findRewardTitlesByChallengeId"
+            resultType="com.yumyumcoach.domain.challenge.dto.RewardTitleResponse">
+        SELECT
+            cr.difficulty_code      AS difficultyCode,
+            cd.name                AS difficultyName,
+            cr.required_success_days AS requiredSuccessDays,
+            cr.daily_target_value   AS dailyTargetValue,
+
+            t.id                    AS titleId,
+            t.icon_emoji            AS iconEmoji,
+            t.name                  AS titleName,
+            t.description           AS titleDescription
+        FROM challenge_rules cr
+                 JOIN titles t ON t.id = cr.reward_title_id
+                 LEFT JOIN challenge_difficulties cd ON cd.code = cr.difficulty_code
+        WHERE cr.challenge_id = #{challengeId}
+        ORDER BY FIELD(cr.difficulty_code,'BEGINNER','INTERMEDIATE','ADVANCED')
     </select>
 
 </mapper>

--- a/src/main/resources/mapper/title/TitleMapper.xml
+++ b/src/main/resources/mapper/title/TitleMapper.xml
@@ -3,7 +3,7 @@
         PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
         "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
-<mapper namespace="com.yumyumcoach.domain.user.mapper.UserTitleMapper">
+<mapper namespace="com.yumyumcoach.domain.title.mapper.TitleMapper">
 
     <!-- 내가 보유한 타이틀인지 여부 -->
     <select id="ownsTitle" resultType="boolean">
@@ -16,7 +16,7 @@
     </select>
 
     <!-- 현재 대표 타이틀 조회 -->
-    <select id="findCurrentTitle" resultType="com.yumyumcoach.domain.user.dto.MyTitleResponse">
+    <select id="findCurrentTitle" resultType="com.yumyumcoach.domain.title.dto.MyTitleResponse">
         SELECT
             p.display_title_id AS currentTitleId,
             t.name AS currentTitleName
@@ -28,14 +28,22 @@
 
     <!-- 내가 보유한 타이틀 목록 -->
     <!-- MyPageResponse 내부 static class는 '$'로 참조 -->
-    <select id="findMyTitles" resultType="com.yumyumcoach.domain.user.dto.MyPageResponse$TitleItem">
+    <select id="findMyTitles" resultType="com.yumyumcoach.domain.title.dto.MyTitleItemResponse">
         SELECT
-            t.id AS titleId,
-            t.name AS name,
-            t.description AS description
+        t.id            AS titleId,
+        t.icon_emoji    AS iconEmoji,
+        t.name          AS name,
+        t.description   AS description,
+        at.obtained_at  AS obtainedAt,
+        at.source_challenge_id AS sourceChallengeId,
+        cd.name         AS difficultyName
         FROM account_titles at
-        JOIN titles t
-        ON t.id = at.title_id
+        JOIN titles t ON t.id = at.title_id
+        LEFT JOIN challenge_rules cr
+        ON cr.challenge_id = at.source_challenge_id
+        AND cr.reward_title_id = at.title_id        <!-- ★ reward_title_id 컬럼 있어야 함 -->
+        LEFT JOIN challenge_difficulties cd
+        ON cd.code = cr.difficulty_code
         WHERE at.email = #{email}
         ORDER BY at.obtained_at DESC
     </select>


### PR DESCRIPTION
## 🔗 관련 이슈

> closes #66 

## ✨ 작업 내용

> domain.title 도메인 생성 및 titles 관련 코드 이동
> 마이페이지 타이틀 API 3종 추가(대표 조회/변경, 보유 목록)
> Postman으로 대표 타이틀 조회/변경/목록 조회 확인

## 📌 참고 사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
