### PR TITLE
fix(#73): user API 명세/응답 iconEmoji 반영 + PATCH 변경

### DIFF
--- a/src/main/groovy/com/yumyumcoach/domain/title/dto/SelectMyTitleRequest.java
+++ b/src/main/groovy/com/yumyumcoach/domain/title/dto/SelectMyTitleRequest.java
@@ -1,0 +1,12 @@
+package com.yumyumcoach.domain.title.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SelectMyTitleRequest {
+    private Long titleId;
+}

--- a/src/main/groovy/com/yumyumcoach/domain/user/controller/UserController.java
+++ b/src/main/groovy/com/yumyumcoach/domain/user/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.yumyumcoach.domain.user.controller;
 
+import com.yumyumcoach.domain.title.dto.SelectMyTitleRequest;
 import com.yumyumcoach.domain.user.dto.MyPageResponse;
 import com.yumyumcoach.domain.title.dto.MyTitleResponse;
 import com.yumyumcoach.domain.user.dto.UpdateMyBasicInfoRequest;
@@ -47,10 +48,10 @@ public class UserController {
     /**
      * 내 대표뱃지 설정
      */
-    @PutMapping("/titles/{titleId}")
-    public MyTitleResponse selectMyTitle(@PathVariable("titleId") Long titleId) {
+    @PatchMapping("/title")
+    public MyTitleResponse selectMyTitle(@RequestBody SelectMyTitleRequest request) {
         String email = CurrentUser.email();
-        return userService.selectMyTitle(email, titleId);
+        return userService.selectMyTitle(email, request.getTitleId());
     }
 }
 

--- a/src/main/groovy/com/yumyumcoach/domain/user/dto/MyPageResponse.java
+++ b/src/main/groovy/com/yumyumcoach/domain/user/dto/MyPageResponse.java
@@ -1,5 +1,6 @@
 package com.yumyumcoach.domain.user.dto;
 
+import com.yumyumcoach.domain.title.dto.MyTitleItemResponse;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -50,7 +51,7 @@ public class MyPageResponse {
     public static class Badges {
         private Long currentTitleId;      // profiles.display_title_id
         private String currentTitleName;  // titles.name
-        private List<TitleItem> titles;   // account_titles 기준
+        private List<MyTitleItemResponse> titles;   // account_titles 기준
     }
 
     @Getter @Builder @NoArgsConstructor @AllArgsConstructor
@@ -58,6 +59,7 @@ public class MyPageResponse {
         private Long titleId;       // titles.id
         private String name;        // titles.name
         private String description; // titles.description
+        private String iconEmoji;
     }
 
     @Getter @Builder @NoArgsConstructor @AllArgsConstructor

--- a/src/main/groovy/com/yumyumcoach/domain/user/service/UserService.java
+++ b/src/main/groovy/com/yumyumcoach/domain/user/service/UserService.java
@@ -48,15 +48,15 @@ public class UserService {
         long followings = followMapper.countFollowings(email);
 
         MyTitleResponse current = titleMapper.findCurrentTitle(email);
-        List<MyTitleItemResponse> myTitleDtos = titleMapper.findMyTitles(email);
 
-        List<MyPageResponse.TitleItem> myTitles = myTitleDtos.stream()
-                .map(t -> MyPageResponse.TitleItem.builder()
-                        .titleId(t.getTitleId())
-                        .name(t.getName())
-                        .description(t.getDescription())
-                        .build())
-                .toList();
+        Long currentTitleId = null;
+        String currentTitleName = null;
+
+        if (current != null) {
+            currentTitleId = current.getCurrentTitleId();
+            currentTitleName = current.getCurrentTitleName();
+        }
+        List<MyTitleItemResponse> myTitles = titleMapper.findMyTitles(email);
 
         return MyPageResponse.builder()
                 .basic(MyPageResponse.Basic.builder()
@@ -79,8 +79,8 @@ public class UserService {
                         .activityLevel(profile.getActivityLevel())
                         .build())
                 .badges(MyPageResponse.Badges.builder()
-                        .currentTitleId(current.getCurrentTitleId())
-                        .currentTitleName(current.getCurrentTitleName())
+                        .currentTitleId(currentTitleId)
+                        .currentTitleName(currentTitleName)
                         .titles(myTitles)
                         .build())
                 .follow(MyPageResponse.Follow.builder()
@@ -191,6 +191,20 @@ public class UserService {
 
     @Transactional
     public MyTitleResponse selectMyTitle(String email, Long titleId) {
+
+        if (titleId == null) {
+            int updated = profileMapper.updateDisplayTitle(email, null);
+            if (updated == 0) {
+                throw new BusinessException(ErrorCode.PROFILE_NOT_FOUND);
+            }
+            // 해제면 current null 내려주게
+            return MyTitleResponse.builder()
+                    .currentTitleId(null)
+                    .currentTitleName(null)
+                    .currentTitleEmoji(null)
+                    .build();
+            // 또는 titleMapper.findCurrentTitle(email)가 null-safe면 그걸 써도 됨
+        }
 
         if (!titleMapper.ownsTitle(email, titleId)) {
             throw new BusinessException(ErrorCode.USER_TITLE_NOT_FOUND);

--- a/src/main/resources/mapper/title/TitleMapper.xml
+++ b/src/main/resources/mapper/title/TitleMapper.xml
@@ -27,23 +27,26 @@
     </select>
 
     <!-- 내가 보유한 타이틀 목록 -->
-    <!-- MyPageResponse 내부 static class는 '$'로 참조 -->
-    <select id="findMyTitles" resultType="com.yumyumcoach.domain.title.dto.MyTitleItemResponse">
+    <select id="findMyTitles" parameterType="string"
+            resultType="com.yumyumcoach.domain.title.dto.MyTitleItemResponse">
         SELECT
-        t.id            AS titleId,
-        t.icon_emoji    AS iconEmoji,
-        t.name          AS name,
-        t.description   AS description,
-        at.obtained_at  AS obtainedAt,
-        at.source_challenge_id AS sourceChallengeId,
-        cd.name         AS difficultyName
+            t.id AS titleId,
+            t.icon_emoji AS iconEmoji,
+            t.name AS name,
+            t.description AS description,
+            at.obtained_at AS obtainedAt,
+            at.source_challenge_id AS sourceChallengeId,
+            CASE cr.difficulty_code
+                WHEN 'BEGINNER' THEN '초급'
+                WHEN 'INTERMEDIATE' THEN '중급'
+                WHEN 'ADVANCED' THEN '고급'
+                ELSE NULL
+                END AS difficultyName
         FROM account_titles at
-        JOIN titles t ON t.id = at.title_id
-        LEFT JOIN challenge_rules cr
-        ON cr.challenge_id = at.source_challenge_id
-        AND cr.reward_title_id = at.title_id        <!-- ★ reward_title_id 컬럼 있어야 함 -->
-        LEFT JOIN challenge_difficulties cd
-        ON cd.code = cr.difficulty_code
+    JOIN titles t ON t.id = at.title_id
+            LEFT JOIN challenge_rules cr
+            ON cr.challenge_id = at.source_challenge_id
+            AND cr.reward_title_id = at.title_id
         WHERE at.email = #{email}
         ORDER BY at.obtained_at DESC
     </select>


### PR DESCRIPTION
## 🔗 관련 이슈

> closes #73 

## ✨ 작업 내용

> 유저/타이틀 명세에서 iconUrl → iconEmoji로 통일
> 대표 타이틀 변경 API를 PATCH 기준으로 전환
> 연동 확인용 테스트 완료

## 📌 참고 사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
