### PR TITLE
feat(#75): 상대방 프로필 조회 API 구현

### DIFF
--- a/src/main/groovy/com/yumyumcoach/domain/title/dto/SelectMyTitleRequest.java
+++ b/src/main/groovy/com/yumyumcoach/domain/title/dto/SelectMyTitleRequest.java
@@ -1,0 +1,12 @@
+package com.yumyumcoach.domain.title.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SelectMyTitleRequest {
+    private Long titleId;
+}

--- a/src/main/groovy/com/yumyumcoach/domain/user/controller/UserController.java
+++ b/src/main/groovy/com/yumyumcoach/domain/user/controller/UserController.java
@@ -5,13 +5,14 @@ import com.yumyumcoach.domain.user.dto.MyPageResponse;
 import com.yumyumcoach.domain.title.dto.MyTitleResponse;
 import com.yumyumcoach.domain.user.dto.UpdateMyBasicInfoRequest;
 import com.yumyumcoach.domain.user.dto.UpdateMyHealthInfoRequest;
+import com.yumyumcoach.domain.user.dto.UserProfileResponse;
 import com.yumyumcoach.domain.user.service.UserService;
 import com.yumyumcoach.global.common.CurrentUser;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/api/users/me")
+@RequestMapping("/api/users")
 @RequiredArgsConstructor
 public class UserController {
 
@@ -20,7 +21,7 @@ public class UserController {
     /**
      * 내 마이페이지 조회
      */
-    @GetMapping("/mypage")
+    @GetMapping("/me/mypage")
     public MyPageResponse getMyPage() {
         String email = CurrentUser.email();
         return userService.getMyPage(email);
@@ -30,7 +31,7 @@ public class UserController {
      * 내 기본정보 수정
      * - (username / profileImageUrl / introduction)
      */
-    @PatchMapping("/basic")
+    @PatchMapping("/me/basic")
     public MyPageResponse.Basic updateMyBasicInfo(@RequestBody UpdateMyBasicInfoRequest request) {
         String email = CurrentUser.email();
         return userService.updateMyBasicInfo(email, request);
@@ -39,7 +40,7 @@ public class UserController {
     /**
      * 내 건강정보 수정
      */
-    @PatchMapping("/health")
+    @PatchMapping("/me/health")
     public MyPageResponse.Health updateMyHealthInfo(@RequestBody UpdateMyHealthInfoRequest request) {
         String email = CurrentUser.email();
         return userService.updateMyHealthInfo(email, request);
@@ -48,10 +49,19 @@ public class UserController {
     /**
      * 내 대표뱃지 설정
      */
-    @PatchMapping("/title")
+    @PatchMapping("/me/title")
     public MyTitleResponse selectMyTitle(@RequestBody SelectMyTitleRequest request) {
         String email = CurrentUser.email();
         return userService.selectMyTitle(email, request.getTitleId());
+    }
+
+    /**
+     * 상대방 프로필 조회
+     */
+    @GetMapping("/{userId}")
+    public UserProfileResponse getUserProfile(@PathVariable("userId") Long userId) {
+        String viewerEmail = CurrentUser.email();
+        return userService.getUserProfile(viewerEmail, userId);
     }
 }
 

--- a/src/main/groovy/com/yumyumcoach/domain/user/controller/UserController.java
+++ b/src/main/groovy/com/yumyumcoach/domain/user/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.yumyumcoach.domain.user.controller;
 
+import com.yumyumcoach.domain.title.dto.SelectMyTitleRequest;
 import com.yumyumcoach.domain.user.dto.MyPageResponse;
 import com.yumyumcoach.domain.title.dto.MyTitleResponse;
 import com.yumyumcoach.domain.user.dto.UpdateMyBasicInfoRequest;
@@ -47,10 +48,10 @@ public class UserController {
     /**
      * 내 대표뱃지 설정
      */
-    @PutMapping("/titles/{titleId}")
-    public MyTitleResponse selectMyTitle(@PathVariable("titleId") Long titleId) {
+    @PatchMapping("/title")
+    public MyTitleResponse selectMyTitle(@RequestBody SelectMyTitleRequest request) {
         String email = CurrentUser.email();
-        return userService.selectMyTitle(email, titleId);
+        return userService.selectMyTitle(email, request.getTitleId());
     }
 }
 

--- a/src/main/groovy/com/yumyumcoach/domain/user/dto/MyPageResponse.java
+++ b/src/main/groovy/com/yumyumcoach/domain/user/dto/MyPageResponse.java
@@ -1,5 +1,6 @@
 package com.yumyumcoach.domain.user.dto;
 
+import com.yumyumcoach.domain.title.dto.MyTitleItemResponse;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -50,7 +51,7 @@ public class MyPageResponse {
     public static class Badges {
         private Long currentTitleId;      // profiles.display_title_id
         private String currentTitleName;  // titles.name
-        private List<TitleItem> titles;   // account_titles 기준
+        private List<MyTitleItemResponse> titles;   // account_titles 기준
     }
 
     @Getter @Builder @NoArgsConstructor @AllArgsConstructor
@@ -58,6 +59,7 @@ public class MyPageResponse {
         private Long titleId;       // titles.id
         private String name;        // titles.name
         private String description; // titles.description
+        private String iconEmoji;
     }
 
     @Getter @Builder @NoArgsConstructor @AllArgsConstructor

--- a/src/main/groovy/com/yumyumcoach/domain/user/dto/UserProfileResponse.java
+++ b/src/main/groovy/com/yumyumcoach/domain/user/dto/UserProfileResponse.java
@@ -1,0 +1,51 @@
+package com.yumyumcoach.domain.user.dto;
+
+import com.yumyumcoach.domain.title.dto.MyTitleItemResponse;
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserProfileResponse {
+
+    private Basic basic;
+    private Follow follow;
+    private Badges badges;
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Basic {
+        private Long userId;
+        private String username;
+        private String profileImageUrl;
+        private String introduction;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Follow {
+        private long followersCount;
+        private long followingsCount;
+        private boolean isFollowing;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Badges {
+        private Long currentTitleId;     // null 가능
+        private String currentTitleName; // null 가능
+        private String currentIconEmoji; // null 가능
+
+        private List<MyTitleItemResponse> titles;
+    }
+}
+

--- a/src/main/groovy/com/yumyumcoach/domain/user/dto/UserProfileRow.java
+++ b/src/main/groovy/com/yumyumcoach/domain/user/dto/UserProfileRow.java
@@ -1,0 +1,19 @@
+package com.yumyumcoach.domain.user.dto;
+
+import lombok.*;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserProfileRow {
+    private Long userId;
+    private String email;
+    private String username;
+    private String introduction;
+    private String profileImageUrl;
+
+    private Long currentTitleId;      // nullable
+    private String currentTitleName;  // nullable
+    private String currentTitleIconEmoji; // nullable
+}

--- a/src/main/groovy/com/yumyumcoach/domain/user/mapper/ProfileMapper.java
+++ b/src/main/groovy/com/yumyumcoach/domain/user/mapper/ProfileMapper.java
@@ -1,5 +1,6 @@
 package com.yumyumcoach.domain.user.mapper;
 
+import com.yumyumcoach.domain.user.dto.UserProfileRow;
 import com.yumyumcoach.domain.user.entity.Profile;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
@@ -37,5 +38,10 @@ public interface ProfileMapper {
      */
     int updateDisplayTitle(@Param("email") String email,
                            @Param("displayTitleId") Long displayTitleId);
+
+    /**
+     * 상대방 프로필 조회
+     */
+    UserProfileRow findUserProfileRow(@Param("userId") Long userId);
 }
 

--- a/src/main/groovy/com/yumyumcoach/domain/user/service/UserService.java
+++ b/src/main/groovy/com/yumyumcoach/domain/user/service/UserService.java
@@ -7,6 +7,7 @@ import com.yumyumcoach.domain.title.dto.MyTitleResponse;
 import com.yumyumcoach.domain.user.dto.MyPageResponse;
 import com.yumyumcoach.domain.user.dto.UpdateMyBasicInfoRequest;
 import com.yumyumcoach.domain.user.dto.UpdateMyHealthInfoRequest;
+import com.yumyumcoach.domain.user.dto.UserProfileResponse;
 import com.yumyumcoach.domain.user.entity.Profile;
 import com.yumyumcoach.domain.user.mapper.FollowMapper;
 import com.yumyumcoach.domain.user.mapper.ProfileMapper;
@@ -19,6 +20,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Collections;
 import java.util.List;
 
 @Service
@@ -216,5 +218,59 @@ public class UserService {
         }
 
         return titleMapper.findCurrentTitle(email);
+    }
+
+    public UserProfileResponse getUserProfile(String viewerEmail, Long userId) {
+
+        // 1) userId -> targetEmail
+        String targetEmail = accountMapper.findEmailById(userId);
+        if (targetEmail == null) {
+            throw new BusinessException(ErrorCode.USER_NOT_FOUND);
+        }
+
+        // 2) 계정 / 프로필 조회
+        Account targetAccount = accountMapper.findByEmail(targetEmail);
+        if (targetAccount == null) {
+            throw new BusinessException(ErrorCode.USER_NOT_FOUND);
+        }
+
+        Profile targetProfile = profileMapper.findByEmail(targetEmail);
+        if (targetProfile == null) {
+            throw new BusinessException(ErrorCode.PROFILE_NOT_FOUND);
+        }
+
+        // 3) 팔로우 요약 + isFollowing
+        long followers = followMapper.countFollowers(targetEmail);
+        long followings = followMapper.countFollowings(targetEmail);
+
+        boolean isFollowing = false;
+        if (viewerEmail != null && !viewerEmail.equals(targetEmail)) {
+            isFollowing = followMapper.exists(viewerEmail, targetEmail);
+        }
+
+        // 4) 대표 타이틀(없을 수 있음) + 보유 타이틀 목록
+        MyTitleResponse current = titleMapper.findCurrentTitle(targetEmail); // null 가능
+        List<MyTitleItemResponse> titles = titleMapper.findMyTitles(targetEmail);
+
+        // 5) 응답 조립 (email 없이)
+        return UserProfileResponse.builder()
+                .basic(UserProfileResponse.Basic.builder()
+                        .userId(userId)
+                        .username(targetAccount.getUsername())
+                        .profileImageUrl(cdnUrlResolver.resolve(targetProfile.getProfileImageUrl()))
+                        .introduction(targetProfile.getIntroduction())
+                        .build())
+                .follow(UserProfileResponse.Follow.builder()
+                        .followersCount(followers)
+                        .followingsCount(followings)
+                        .isFollowing(isFollowing)
+                        .build())
+                .badges(UserProfileResponse.Badges.builder()
+                        .currentTitleId(current != null ? current.getCurrentTitleId() : null)
+                        .currentTitleName(current != null ? current.getCurrentTitleName() : null)
+                        .currentIconEmoji(current != null ? current.getCurrentTitleEmoji() : null)
+                        .titles(titles)
+                        .build())
+                .build();
     }
 }

--- a/src/main/groovy/com/yumyumcoach/domain/user/service/UserService.java
+++ b/src/main/groovy/com/yumyumcoach/domain/user/service/UserService.java
@@ -48,15 +48,15 @@ public class UserService {
         long followings = followMapper.countFollowings(email);
 
         MyTitleResponse current = titleMapper.findCurrentTitle(email);
-        List<MyTitleItemResponse> myTitleDtos = titleMapper.findMyTitles(email);
 
-        List<MyPageResponse.TitleItem> myTitles = myTitleDtos.stream()
-                .map(t -> MyPageResponse.TitleItem.builder()
-                        .titleId(t.getTitleId())
-                        .name(t.getName())
-                        .description(t.getDescription())
-                        .build())
-                .toList();
+        Long currentTitleId = null;
+        String currentTitleName = null;
+
+        if (current != null) {
+            currentTitleId = current.getCurrentTitleId();
+            currentTitleName = current.getCurrentTitleName();
+        }
+        List<MyTitleItemResponse> myTitles = titleMapper.findMyTitles(email);
 
         return MyPageResponse.builder()
                 .basic(MyPageResponse.Basic.builder()
@@ -79,8 +79,8 @@ public class UserService {
                         .activityLevel(profile.getActivityLevel())
                         .build())
                 .badges(MyPageResponse.Badges.builder()
-                        .currentTitleId(current.getCurrentTitleId())
-                        .currentTitleName(current.getCurrentTitleName())
+                        .currentTitleId(currentTitleId)
+                        .currentTitleName(currentTitleName)
                         .titles(myTitles)
                         .build())
                 .follow(MyPageResponse.Follow.builder()
@@ -191,6 +191,20 @@ public class UserService {
 
     @Transactional
     public MyTitleResponse selectMyTitle(String email, Long titleId) {
+
+        if (titleId == null) {
+            int updated = profileMapper.updateDisplayTitle(email, null);
+            if (updated == 0) {
+                throw new BusinessException(ErrorCode.PROFILE_NOT_FOUND);
+            }
+            // 해제면 current null 내려주게
+            return MyTitleResponse.builder()
+                    .currentTitleId(null)
+                    .currentTitleName(null)
+                    .currentTitleEmoji(null)
+                    .build();
+            // 또는 titleMapper.findCurrentTitle(email)가 null-safe면 그걸 써도 됨
+        }
 
         if (!titleMapper.ownsTitle(email, titleId)) {
             throw new BusinessException(ErrorCode.USER_TITLE_NOT_FOUND);

--- a/src/main/resources/mapper/title/TitleMapper.xml
+++ b/src/main/resources/mapper/title/TitleMapper.xml
@@ -27,23 +27,26 @@
     </select>
 
     <!-- 내가 보유한 타이틀 목록 -->
-    <!-- MyPageResponse 내부 static class는 '$'로 참조 -->
-    <select id="findMyTitles" resultType="com.yumyumcoach.domain.title.dto.MyTitleItemResponse">
+    <select id="findMyTitles" parameterType="string"
+            resultType="com.yumyumcoach.domain.title.dto.MyTitleItemResponse">
         SELECT
-        t.id            AS titleId,
-        t.icon_emoji    AS iconEmoji,
-        t.name          AS name,
-        t.description   AS description,
-        at.obtained_at  AS obtainedAt,
-        at.source_challenge_id AS sourceChallengeId,
-        cd.name         AS difficultyName
+            t.id AS titleId,
+            t.icon_emoji AS iconEmoji,
+            t.name AS name,
+            t.description AS description,
+            at.obtained_at AS obtainedAt,
+            at.source_challenge_id AS sourceChallengeId,
+            CASE cr.difficulty_code
+                WHEN 'BEGINNER' THEN '초급'
+                WHEN 'INTERMEDIATE' THEN '중급'
+                WHEN 'ADVANCED' THEN '고급'
+                ELSE NULL
+                END AS difficultyName
         FROM account_titles at
-        JOIN titles t ON t.id = at.title_id
-        LEFT JOIN challenge_rules cr
-        ON cr.challenge_id = at.source_challenge_id
-        AND cr.reward_title_id = at.title_id        <!-- ★ reward_title_id 컬럼 있어야 함 -->
-        LEFT JOIN challenge_difficulties cd
-        ON cd.code = cr.difficulty_code
+    JOIN titles t ON t.id = at.title_id
+            LEFT JOIN challenge_rules cr
+            ON cr.challenge_id = at.source_challenge_id
+            AND cr.reward_title_id = at.title_id
         WHERE at.email = #{email}
         ORDER BY at.obtained_at DESC
     </select>

--- a/src/main/resources/mapper/user/ProfileMapper.xml
+++ b/src/main/resources/mapper/user/ProfileMapper.xml
@@ -88,4 +88,23 @@
         WHERE email = #{email}
     </update>
 
+    <!-- 상대방 프로필 조회 -->
+    <select id="findUserProfileRow"
+            parameterType="long"
+            resultType="com.yumyumcoach.domain.user.dto.UserProfileRow">
+        SELECT
+            a.id AS userId,
+            a.email AS email,
+            a.username AS username,
+            p.introduction AS introduction,
+            p.profile_image_url AS profileImageUrl,
+            t.id AS currentTitleId,
+            t.name AS currentTitleName,
+            t.icon_emoji AS currentTitleIconEmoji
+        FROM accounts a
+                 JOIN profiles p ON p.email = a.email
+                 LEFT JOIN titles t ON t.id = p.display_title_id
+        WHERE a.id = #{userId}
+    </select>
+
 </mapper>


### PR DESCRIPTION
## 🔗 관련 이슈

> closes #75 

## ✨ 작업 내용

> 상대방 프로필 조회 API 추가
> GET /api/users/{userId} 엔드포인트 추가
> 테스트 정상동작 확인. 노션에 정리 완

## 📌 참고 사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
