### PR TITLE
feat(#59) 운동 검색 API 구현

### DIFF
--- a/src/main/groovy/com/yumyumcoach/domain/exercise/controller/ExerciseController.java
+++ b/src/main/groovy/com/yumyumcoach/domain/exercise/controller/ExerciseController.java
@@ -1,10 +1,13 @@
 package com.yumyumcoach.domain.exercise.controller;
 
 import com.yumyumcoach.domain.exercise.dto.ExerciseResponse;
+import com.yumyumcoach.domain.exercise.dto.SearchResponse;
 import com.yumyumcoach.domain.exercise.service.ExerciseService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -18,5 +21,13 @@ public class ExerciseController {
     @GetMapping
     public List<ExerciseResponse> getExercises() {
         return exerciseService.getExercises();
+    }
+
+    @GetMapping("/search")
+    public ResponseEntity<SearchResponse> search(@RequestParam ("keyword") String keyword,
+                                                 @RequestParam(value = "page", defaultValue = "0") int page,
+                                                 @RequestParam(value = "size", defaultValue = "5") int size) {
+        SearchResponse response = exerciseService.searchExercise(keyword, page, size);
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/groovy/com/yumyumcoach/domain/exercise/dto/SearchDto.java
+++ b/src/main/groovy/com/yumyumcoach/domain/exercise/dto/SearchDto.java
@@ -1,0 +1,16 @@
+package com.yumyumcoach.domain.exercise.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.*;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SearchDto {
+    @NotBlank
+    private String name;
+    private double met;
+    @NotBlank
+    private String type;
+}

--- a/src/main/groovy/com/yumyumcoach/domain/exercise/dto/SearchResponse.java
+++ b/src/main/groovy/com/yumyumcoach/domain/exercise/dto/SearchResponse.java
@@ -1,0 +1,21 @@
+package com.yumyumcoach.domain.exercise.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SearchResponse {
+    private int page;
+    private int size;
+    private int total;
+
+    private List<SearchDto> result;
+}

--- a/src/main/groovy/com/yumyumcoach/domain/exercise/mapper/ExerciseMapper.java
+++ b/src/main/groovy/com/yumyumcoach/domain/exercise/mapper/ExerciseMapper.java
@@ -1,5 +1,8 @@
 package com.yumyumcoach.domain.exercise.mapper;
 
+import com.yumyumcoach.domain.exercise.dto.ExerciseResponse;
+import com.yumyumcoach.domain.exercise.dto.SearchDto;
+import com.yumyumcoach.domain.exercise.dto.SearchResponse;
 import com.yumyumcoach.domain.exercise.entity.Exercise;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
@@ -11,4 +14,10 @@ public interface ExerciseMapper {
     List<Exercise> findAll();
 
     Exercise findById(@Param("exerciseId") Long exerciseId);
+
+    List<SearchDto> searchExercise(@Param("keyword") String keyword,
+                                   @Param("size") int size,
+                                   @Param("offset") int offset);
+
+    int countExercises(@Param("keyword") String keyword);
 }

--- a/src/main/groovy/com/yumyumcoach/domain/exercise/service/ExerciseService.java
+++ b/src/main/groovy/com/yumyumcoach/domain/exercise/service/ExerciseService.java
@@ -10,6 +10,7 @@ import com.yumyumcoach.domain.user.entity.Profile;
 import com.yumyumcoach.domain.user.mapper.ProfileMapper;
 import com.yumyumcoach.global.exception.BusinessException;
 import com.yumyumcoach.global.exception.ErrorCode;
+import groovy.util.logging.Slf4j;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,10 +23,15 @@ import java.util.List;
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
+@Slf4j
 public class ExerciseService {
     private final ExerciseMapper exerciseMapper;
     private final ExerciseRecordMapper exerciseRecordMapper;
     private final ProfileMapper profileMapper;
+
+    private static final int MIN_KEYWORD_LENGTH = 2;
+    private static final int SIZE_LIMIT = 10;
+    private static final int SIZE_DEFAULT = 5;
 
     public List<ExerciseResponse> getExercises() {
         return exerciseMapper.findAll().stream()
@@ -164,6 +170,52 @@ public class ExerciseService {
 
         exerciseRecordMapper.insert(exerciseRecord);
         return getMyExerciseRecordDetail(email, exerciseRecord.getId());
+    }
+
+    // 운동 검색 기능
+    @Transactional(readOnly = true)
+    public SearchResponse searchExercise(String keyword, int page, int size) {
+
+        // 파라미터 예외처리 및 스케일링
+        keyword = validateKeyword(keyword);
+        page = Math.max(0, page);
+        size = normalizeSize(size);
+
+        //offset 설정
+        int offset = page * size;
+
+        // 현재 페이지 결과 조회
+        List<SearchDto> searchResult = exerciseMapper.searchExercise(keyword, size, offset);
+
+        // 전체 개수 조회
+        int total = exerciseMapper.countExercises(keyword);
+
+        return SearchResponse.builder()
+                .page(page)
+                .size(size)
+                .total(total)
+                .result(searchResult)
+                .build();
+    }
+
+    private static int normalizeSize(int size) {
+        if (size <= 0) {
+            size = SIZE_DEFAULT;
+        }
+        else if (size > SIZE_LIMIT) {
+            size = SIZE_LIMIT;
+        }
+
+        return size;
+    }
+
+    private static String validateKeyword(String keyword) {
+        if (keyword == null || keyword.trim().length() < MIN_KEYWORD_LENGTH) {
+            throw new BusinessException(ErrorCode.EXERCISE_INVALID_KEYWORD);
+        }
+        keyword = keyword.trim();
+
+        return keyword;
     }
 }
 

--- a/src/main/groovy/com/yumyumcoach/global/config/SecurityConfig.java
+++ b/src/main/groovy/com/yumyumcoach/global/config/SecurityConfig.java
@@ -43,7 +43,8 @@ public class SecurityConfig {
                                 "/api/auth/check-email",
                                 "/api/auth/check-username",
                                 "/api/auth/sign-up",
-                                "/api/auth/refresh").permitAll()
+                                "/api/auth/refresh",
+                                "/api/exercises/search").permitAll()
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);

--- a/src/main/groovy/com/yumyumcoach/global/exception/ErrorCode.java
+++ b/src/main/groovy/com/yumyumcoach/global/exception/ErrorCode.java
@@ -59,6 +59,7 @@ public enum ErrorCode {
     EXERCISE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 운동을 찾을 수 없습니다."),
     EXERCISE_RECORD_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 운동 기록을 찾을 수 없습니다."),
     EXERCISE_RECORD_FORBIDDEN(HttpStatus.FORBIDDEN, "해당 운동 기록에 대한 권한이 없습니다."),
+    EXERCISE_INVALID_KEYWORD(HttpStatus.BAD_REQUEST, "검색어는 2글자 이상 입력해주세요."),
 
     // ===== IMAGE =====
     IMAGE_UNSUPPORTED_CONTENT_TYPE(HttpStatus.BAD_REQUEST, "지원하지 않는 이미지 형식입니다."),

--- a/src/main/groovy/com/yumyumcoach/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/groovy/com/yumyumcoach/global/jwt/JwtAuthenticationFilter.java
@@ -37,7 +37,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             String uri = request.getRequestURI();
             if(uri.startsWith("/api/auth/sign-in") || uri.startsWith("/api/auth/sign-up") ||
                 uri.startsWith("/api/auth/check-email") || uri.startsWith("/api/auth/check-username") ||
-                uri.startsWith("/api/auth/refresh")) {
+                uri.startsWith("/api/auth/refresh") || uri.startsWith("/api/exercises/search")) {
                 filterChain.doFilter(request,response);
                 return;
             }

--- a/src/main/resources/mapper/exercise/ExerciseMapper.xml
+++ b/src/main/resources/mapper/exercise/ExerciseMapper.xml
@@ -24,4 +24,19 @@
         FROM exercises
         WHERE id = #{exerciseId}
     </select>
+
+    <select id="searchExercise" resultType="com.yumyumcoach.domain.exercise.dto.SearchDto">
+        SELECT name, type, met
+        FROM exercises
+        WHERE name LIKE CONCAT('%', #{keyword}, '%')
+        ORDER BY name ASC
+            LIMIT #{size} OFFSET #{offset}
+    </select>
+
+    <select id="countExercises" resultType="int">
+        SELECT COUNT(*)
+        FROM exercises
+        WHERE name LIKE CONCAT('%', #{keyword}, '%')
+    </select>
+
 </mapper>


### PR DESCRIPTION
## 🔗 관련 이슈

> close:59

## ✨ 작업 내용

> 운동 검색 API 구현

- 운동 이름을 부분 키워드로 검색하는 공개 GET API(`/api/exercises/search`): keyword(필수),
  page/size(기본 0,5) 쿼리로 조회하고, 이름/유형/met만 포함한 결과 목록과 총 개수, 페이지 정보를 반환합니다.

## 📌 참고 사항

> 채택한 페이지네이션 방식, 백 & 프론트의 책임 분배 등은 노션의 검색기능 문서에 정리함
[검색기능문서](https://www.notion.so/dreamgirl11/2d04788e5962800fb9b9eb4316ff85a6)
