### PR TITLE
fix(#88): 운동/식단 기록 변경 시 AI 주간 평가 비동기화 적용

### DIFF
--- a/src/main/groovy/com/yumyumcoach/domain/ai/event/AiReviewEventListener.java
+++ b/src/main/groovy/com/yumyumcoach/domain/ai/event/AiReviewEventListener.java
@@ -1,0 +1,27 @@
+package com.yumyumcoach.domain.ai.event;
+
+import com.yumyumcoach.domain.ai.service.AiBackgroundJobService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionalEventListener;
+import org.springframework.transaction.event.TransactionPhase;
+
+@Component
+@RequiredArgsConstructor
+public class AiReviewEventListener {
+
+    private final AiBackgroundJobService aiBackgroundJobService;
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onExerciseReviewRequested(ExerciseReviewRequestedEvent event) {
+        aiBackgroundJobService.generateExerciseReviewAsync(event.email(), event.anchorDate());
+    }
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onNutritionReviewRequested(NutritionReviewRequestedEvent event) {
+        aiBackgroundJobService.generateNutritionReviewAsync(event.email(), event.anchorDate());
+    }
+}

--- a/src/main/groovy/com/yumyumcoach/domain/ai/event/ExerciseReviewRequestedEvent.java
+++ b/src/main/groovy/com/yumyumcoach/domain/ai/event/ExerciseReviewRequestedEvent.java
@@ -1,0 +1,6 @@
+package com.yumyumcoach.domain.ai.event;
+
+import java.time.LocalDate;
+
+public record ExerciseReviewRequestedEvent(String email, LocalDate anchorDate) {}
+

--- a/src/main/groovy/com/yumyumcoach/domain/ai/event/NutritionReviewRequestedEvent.java
+++ b/src/main/groovy/com/yumyumcoach/domain/ai/event/NutritionReviewRequestedEvent.java
@@ -1,0 +1,5 @@
+package com.yumyumcoach.domain.ai.event;
+
+import java.time.LocalDate;
+
+public record NutritionReviewRequestedEvent(String email, LocalDate anchorDate) {}

--- a/src/main/groovy/com/yumyumcoach/domain/ai/service/AiBackgroundJobService.java
+++ b/src/main/groovy/com/yumyumcoach/domain/ai/service/AiBackgroundJobService.java
@@ -1,0 +1,21 @@
+package com.yumyumcoach.domain.ai.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+
+@Service
+@RequiredArgsConstructor
+public class AiBackgroundJobService {
+
+    private final AiRecommendationService aiRecommendationService;
+
+    public void generateExerciseReviewAsync(String email, LocalDate anchorDate) {
+        aiRecommendationService.generateExerciseReview(email, anchorDate);
+    }
+
+    public void generateNutritionReviewAsync(String email, LocalDate anchorDate) {
+        aiRecommendationService.generateNutritionReview(email, anchorDate);
+    }
+}

--- a/src/main/groovy/com/yumyumcoach/domain/diet/mapper/DietRecordMapper.java
+++ b/src/main/groovy/com/yumyumcoach/domain/diet/mapper/DietRecordMapper.java
@@ -4,6 +4,7 @@ import com.yumyumcoach.domain.diet.dto.CreateDietRecordRequest;
 import com.yumyumcoach.domain.diet.dto.DietRecordDto;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
@@ -46,5 +47,11 @@ public interface DietRecordMapper {
     );
 
     String selectOwnerEmail(@Param("id") Long id);
+
+    LocalDateTime selectRecordedAtByIdAndEmail(
+            @Param("id") Long id,
+            @Param("email") String email
+    );
+
 }
 

--- a/src/main/groovy/com/yumyumcoach/domain/diet/service/DietRecordService.java
+++ b/src/main/groovy/com/yumyumcoach/domain/diet/service/DietRecordService.java
@@ -1,15 +1,18 @@
 package com.yumyumcoach.domain.diet.service;
 
+import com.yumyumcoach.domain.ai.event.NutritionReviewRequestedEvent;
 import com.yumyumcoach.domain.diet.dto.CreateDietRecordRequest;
 import com.yumyumcoach.domain.diet.dto.DietRecordDto;
 import com.yumyumcoach.domain.diet.mapper.DietFoodMapper;
 import com.yumyumcoach.domain.diet.mapper.DietRecordMapper;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 import com.yumyumcoach.global.exception.BusinessException;
 import com.yumyumcoach.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,6 +22,7 @@ public class DietRecordService {
 
     private final DietRecordMapper dietRecordMapper;
     private final DietFoodMapper dietFoodMapper;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Transactional(readOnly = true)
     public List<DietRecordDto> getMyDiets(String email, LocalDate date, int page, int size) {
@@ -47,6 +51,9 @@ public class DietRecordService {
         if (request.getItems() != null && !request.getItems().isEmpty()) {
             dietFoodMapper.insertDietFoods(dietId, request.getItems());
         }
+
+        LocalDate anchor = request.getRecordedAt().toLocalDate();
+        eventPublisher.publishEvent(new NutritionReviewRequestedEvent(email, anchor));
         return dietId;
     }
 
@@ -59,11 +66,18 @@ public class DietRecordService {
         if (!owner.equals(email)) {
             throw new BusinessException(ErrorCode.DIET_FORBIDDEN);
         }
+
+        LocalDateTime recorededAt = dietRecordMapper.selectRecordedAtByIdAndEmail(dietId, email);
+        if (recorededAt == null) throw new BusinessException(ErrorCode.DIET_FORBIDDEN);
+        LocalDate anchor = recorededAt.toLocalDate();
+
         dietFoodMapper.deleteDietFoodsByDietId(dietId);
         int deleted = dietRecordMapper.deleteDietRecord(dietId, email);
         if (deleted == 0) {
             throw new BusinessException(ErrorCode.DIET_NOT_FOUND);
         }
+
+        eventPublisher.publishEvent(new NutritionReviewRequestedEvent(email, anchor));
     }
 
     @Transactional
@@ -84,6 +98,9 @@ public class DietRecordService {
         if (request.getItems() != null && !request.getItems().isEmpty()) {
             dietFoodMapper.insertDietFoods(dietId, request.getItems());
         }
+
+        LocalDate anchor = request.getRecordedAt().toLocalDate();
+        eventPublisher.publishEvent(new NutritionReviewRequestedEvent(email, anchor));
     }
 }
 

--- a/src/main/groovy/com/yumyumcoach/domain/exercise/service/ExerciseService.java
+++ b/src/main/groovy/com/yumyumcoach/domain/exercise/service/ExerciseService.java
@@ -1,5 +1,7 @@
 package com.yumyumcoach.domain.exercise.service;
 
+import com.yumyumcoach.domain.ai.event.ExerciseReviewRequestedEvent;
+import com.yumyumcoach.domain.ai.service.AiBackgroundJobService;
 import com.yumyumcoach.domain.exercise.dto.*;
 import com.yumyumcoach.domain.exercise.entity.Exercise;
 import com.yumyumcoach.domain.exercise.entity.ExerciseRecord;
@@ -12,11 +14,13 @@ import com.yumyumcoach.global.exception.BusinessException;
 import com.yumyumcoach.global.exception.ErrorCode;
 import groovy.util.logging.Slf4j;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -28,6 +32,7 @@ public class ExerciseService {
     private final ExerciseMapper exerciseMapper;
     private final ExerciseRecordMapper exerciseRecordMapper;
     private final ProfileMapper profileMapper;
+    private final ApplicationEventPublisher eventPublisher;
 
     private static final int MIN_KEYWORD_LENGTH = 2;
     private static final int SIZE_LIMIT = 10;
@@ -39,7 +44,7 @@ public class ExerciseService {
                 .toList();
     }
 
-    public List<ExerciseRecordResponse> getMyExerciseRecords(String email, java.time.LocalDate recordDate) {
+    public List<ExerciseRecordResponse> getMyExerciseRecords(String email, LocalDate recordDate) {
         return exerciseRecordMapper.findByEmailAndDate(email, recordDate).stream()
                 .map(this::toExerciseRecordResponse)
                 .toList();
@@ -57,9 +62,14 @@ public class ExerciseService {
 
     @Transactional
     public List<ExerciseRecordResponse> createMyExerciseRecords(String email, List<ExerciseRecordRequest> requests) {
-        return requests.stream()
+        List<ExerciseRecordResponse> result = requests.stream()
                 .map(req -> createExerciseRecord(email, req))
                 .toList();
+
+        LocalDate anchor = requests.get(requests.size() - 1).getRecordedAt().toLocalDate();
+        eventPublisher.publishEvent(new ExerciseReviewRequestedEvent(email, anchor));
+
+        return result;
     }
 
     @Transactional
@@ -78,15 +88,21 @@ public class ExerciseService {
                 .build();
 
         exerciseRecordMapper.update(exerciseRecord);
+
+        LocalDate anchor = request.getRecordedAt().toLocalDate();
+        eventPublisher.publishEvent(new ExerciseReviewRequestedEvent(email, anchor));
         return getMyExerciseRecordDetail(email, recordId);
     }
 
     @Transactional
     public DeleteExerciseRecordResponse deleteMyExerciseRecord(String email, Long recordId) {
         checkRecordOwnerOrThrow(email, recordId);
-
+        ExerciseRecordWithExercise before = exerciseRecordMapper.findDetailByIdAndEmail(recordId, email);
+        if (before == null) throw new BusinessException(ErrorCode.EXERCISE_RECORD_NOT_FOUND);
         exerciseRecordMapper.delete(recordId, email);
 
+        LocalDate anchor = before.getRecordedAt().toLocalDate();
+        eventPublisher.publishEvent(new ExerciseReviewRequestedEvent(email, anchor));
         return DeleteExerciseRecordResponse.builder()
                 .recordId(recordId)
                 .deleted(true)

--- a/src/main/groovy/com/yumyumcoach/global/config/AsyncConfig.java
+++ b/src/main/groovy/com/yumyumcoach/global/config/AsyncConfig.java
@@ -1,0 +1,8 @@
+package com.yumyumcoach.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {}

--- a/src/main/resources/mapper/diet/DietRecordMapper.xml
+++ b/src/main/resources/mapper/diet/DietRecordMapper.xml
@@ -65,15 +65,17 @@
     </select>
 
     <!-- 사용자별 특정 날짜 식단 목록 (페이징) -->
-    <select id="selectDietRecordsByUserAndDate" resultType="com.yumyumcoach.domain.diet.dto.DietRecordDto">
+    <select id="selectDietRecordsByUserAndDate"
+            resultType="com.yumyumcoach.domain.diet.dto.DietRecordDto">
         SELECT
             id,
-            DATE(recorded_at) AS recordedAt,
-            meal_type         AS mealType,
-            image_url         AS imageUrl
+            recorded_at      AS recordedAt,
+            meal_type        AS mealType,
+            image_url        AS imageUrl
         FROM diet_records
         WHERE email = #{email}
-          AND DATE(recorded_at) = #{recordedAt}
+          AND recorded_at >= CONCAT(#{recordedAt}, ' 00:00:00')
+          AND recorded_at &lt;  DATE_ADD(CONCAT(#{recordedAt}, ' 00:00:00'), INTERVAL 1 DAY)
         ORDER BY recorded_at DESC, id DESC
         LIMIT #{limit} OFFSET #{offset}
     </select>
@@ -101,7 +103,7 @@
         UPDATE diet_records
         SET
             recorded_at = #{req.recordedAt},
-            meal_type   = #{req.mealType}
+            meal_type   = #{req.mealType},
             image_url   = #{req.imageUrl}
         WHERE id = #{id}
           AND email = #{email}
@@ -118,6 +120,13 @@
         SELECT email
         FROM diet_records
         WHERE id = #{id}
+    </select>
+
+    <select id="selectRecordedAtByIdAndEmail" resultType="java.time.LocalDateTime">
+        SELECT recorded_at
+        FROM diet_records
+        WHERE id = #{id}
+          AND email = #{email}
     </select>
 
 </mapper>


### PR DESCRIPTION
## 🔗 관련 이슈

> closes #88 

## ✨ 작업 내용

> 운동 기록 생성/수정/삭제 시 AI 주간 평가 트리거를 이벤트 기반으로 분리
> 트랜잭션 커밋 이후 비동기(@Async)로 AI 평가 실행
> 생성/수정/삭제 후에도 해당 주 기준으로 평가 재생성되도록 처리
> DietFoodMapper.xml 문법 오류 수정

## 📌 참고 사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
